### PR TITLE
build: add CMake based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15.1)
+
+project(PythonKit
+  LANGUAGES Swift)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
+
+include(SwiftSupport)
+
+add_subdirectory(PythonKit)
+add_subdirectory(cmake/modules)

--- a/PythonKit/CMakeLists.txt
+++ b/PythonKit/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(PythonKit
+  NumpyConversion.swift
+  Python.swift
+  PythonLibrary+Symbols.swift
+  PythonLibrary.swift)
+set_target_properties(PythonKit PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR})
+
+get_swift_host_arch(swift_arch)
+install(TARGETS PythonKit
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  RUNTIME DESTINATION bin)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftdoc
+  ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftmodule
+  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>/${swift_arch})
+set_property(GLOBAL APPEND PROPERTY PythonKit_EXPORTS PythonKit)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(PythonKit_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/PythonKitExports.cmake)
+configure_file(PythonKitConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/PythonKitConfig.cmake)
+
+get_property(PythonKit_EXPORTS GLOBAL PROPERTY PythonKit_EXPORTS)
+export(TARGETS ${PythonKit_EXPORTS} FILE ${PythonKit_EXPORTS_FILE})

--- a/cmake/modules/PythonKitConfig.cmake.in
+++ b/cmake/modules/PythonKitConfig.cmake.in
@@ -1,0 +1,3 @@
+if(NOT TARGET PythonKit)
+  include(@PythonKit_EXPORTS_FILE@)
+endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,0 +1,36 @@
+# Returns the current architecture name in a variable
+#
+# Usage:
+#   get_swift_host_arch(result_var_name)
+#
+# If the current architecture is supported by Swift, sets ${result_var_name}
+# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
+function(get_swift_host_arch result_var_name)
+  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
+    set("${result_var_name}" "aarch64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
+    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
+    set("${result_var_name}" "s390x" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
+    set("${result_var_name}" "armv6" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
+    set("${result_var_name}" "armv7" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64")
+    set("${result_var_name}" "x86_64" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
+    set("${result_var_name}" "itanium" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
+    set("${result_var_name}" "i686" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+  endif()
+endfunction()


### PR DESCRIPTION
This adds a CMake based build for PythonKit, currently limited to just
the PythonKit module.  This will allow optionally building PythonKit as
part of a Swift toolchain build so that it can be vended by a toolchain
distribution.

This is also required to support building this on the Windows platform
where swift-package-manager is not yet ready.