### PR TITLE
build: bifurcate the paths for Linux, Windows and macOS

### DIFF
--- a/PythonKit/CMakeLists.txt
+++ b/PythonKit/CMakeLists.txt
@@ -12,10 +12,17 @@ install(TARGETS PythonKit
   ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}
   LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}
   RUNTIME DESTINATION bin)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PythonKit.swiftdoc
-  DESTINATION  lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
-  RENAME ${swift_arch}.swiftdoc)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PythonKit.swiftmodule
-  DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
-  RENAME ${swift_arch}.swiftmodule)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftdoc
+    DESTINATION  lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
+    RENAME ${swift_arch}.swiftdoc)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftmodule
+    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
+    RENAME ${swift_arch}.swiftmodule)
+else()
+  install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftdoc
+    ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftmodule
+    DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/${swift_arch})
+endif()
 set_property(GLOBAL APPEND PROPERTY PythonKit_EXPORTS PythonKit)


### PR DESCRIPTION
The Linux and Windows paths are identical, but the macOS paths are
different.  Unfortunately, although the compiler looks in the directory,
it does not pick up the right paths.