### PR TITLE
build: use more generic CMake patterns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(PythonKit
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
 include(SwiftSupport)
 
 add_subdirectory(PythonKit)

--- a/PythonKit/CMakeLists.txt
+++ b/PythonKit/CMakeLists.txt
@@ -13,16 +13,16 @@ install(TARGETS PythonKit
   LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}
   RUNTIME DESTINATION bin)
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftdoc
+  install(FILES $<TARGET_PROPERTY:PythonKit,Swift_MODULE_DIRECTORY>/PythonKit.swiftdoc
     DESTINATION  lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
     RENAME ${swift_arch}.swiftdoc)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftmodule
+  install(FILES $<TARGET_PROPERTY:PythonKit,Swift_MODULE_DIRECTORY>/PythonKit.swiftmodule
     DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/PythonKit.swiftmodule
     RENAME ${swift_arch}.swiftmodule)
 else()
   install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftdoc
-    ${CMAKE_CURRENT_BINARY_DIR}/swift/PythonKit.swiftmodule
+    $<TARGET_PROPERTY:PythonKit,Swift_MODULE_DIRECTORY>/PythonKit.swiftdoc
+    $<TARGET_PROPERTY:PythonKit,Swift_MODULE_DIRECTORY>/PythonKit.swiftmodule
     DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${swift_os}/${swift_arch})
 endif()
 set_property(GLOBAL APPEND PROPERTY PythonKit_EXPORTS PythonKit)


### PR DESCRIPTION
This uses the generic CMake patterns of CMAKE_Swift_MODULE_DIRECTORY and
using the TARGET_PROPERTY generator expression rather than hardcoding
paths.