### PR TITLE
Update swift argument parser dependency to version 0.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pvieito/LoggerKit.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.2")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Attempting to use version `0.0.2` of swift-argument-parser in a project which also depends on PythonKit results in

```
error: because root depends on swift-argument-parser 0.2.0..<1.0.0 and root depends on swift-argument-parser 0.0.1..<0.1.0, version solving failed.
```

There are probably different ways to resolve this, but I thought it would be nice to update the dependency here to the latest version.