### PR TITLE
Adds Lambda support to PythonKit - use Swift functions as Python lambdas

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
             targets: ["PythonTool"]
         ),
         .library(
+            name: "PythonLambdaSupport", // provides C-based interface to Python
+            targets: ["PythonLambdaSupport"]),
+        .library(
             name: "PythonKit",
             targets: ["PythonKit"]
         )
@@ -25,7 +28,16 @@ let package = Package(
             path: "PythonTool"
         ),
         .target(
+            name: "libpylamsupport",
+            dependencies: []
+        ),
+        .target(
+            name: "PythonLambdaSupport",
+            dependencies: ["libpylamsupport"]
+        ),
+        .target(
             name: "PythonKit",
+            dependencies:[  "PythonLambdaSupport" ],
             path: "PythonKit"
         ),
         .testTarget(

--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -419,6 +419,8 @@ public struct CheckingPythonObject {
         self.base = base
     }
     
+    var ownedPyObject: OwnedPyObjectPointer { get { base.ownedPyObject }}
+    
     public subscript(dynamicMember name: String) -> PythonObject? {
         get {
             let selfObject = base.ownedPyObject

--- a/PythonKit/PythonLambda.swift
+++ b/PythonKit/PythonLambda.swift
@@ -9,7 +9,7 @@ import PythonLambdaSupport
 
 let METH_VARARGS  = Int32(0x0001)
 
-/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice.
+/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice. PythonLambda is only available on Python versions > 3.
 ///
 /// Example:
 ///
@@ -77,7 +77,7 @@ let METH_VARARGS  = Int32(0x0001)
 ///
 public typealias 𝝺 = PythonLambda
 
-/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice.
+/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice. PythonLambda is only available on Python versions > 3.
 ///
 /// Example:
 ///

--- a/PythonKit/PythonLambda.swift
+++ b/PythonKit/PythonLambda.swift
@@ -1,0 +1,403 @@
+//
+//  PythonLambda.swift
+//  
+//
+//  Created by strictlyswift on 7/6/20.
+//
+
+import PythonLambdaSupport
+
+let METH_VARARGS  = Int32(0x0001)
+
+/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice.
+///
+/// Example:
+///
+/// The Python code `map(lambda(x:x*2), [10,12,14] )`  could be written as:
+///
+///         Python.map( 𝝺{x in x*2} , [10,12,14] ) // [20,24,28]
+///
+///
+/// or alternatively, without the special character:
+///
+///         Python.map( PythonLambda {x in x*2} , [10,12,14] ) // [20,24,28]
+///
+/// There are a number of limitations, not least that only a select number of function shapes are supported. These are:
+/// - (Int) -> Int
+/// - (String) -> String
+/// - (String) -> Int
+/// - (Int) -> String
+/// - (Double) -> Double
+/// - (Double) -> Int
+/// - (Double) -> String
+/// - (Int) -> Bool
+/// - (String) -> Bool
+/// - (Double) -> Bool
+/// - (Bool) -> Int
+/// - (Bool) -> String
+/// - (Bool) -> Double
+/// - (Bool) -> Bool
+/// - (PythonObject) -> String
+/// - (PythonObject) -> Int
+/// - (PythonObject) -> Double
+/// - (PythonObject) -> Bool
+/// - (PythonObject) -> PythonObject
+/// - (PythonObject, PythonObject) -> PythonObject
+/// - (PythonObject, PythonObject, PythonObject) -> PythonObject
+///
+/// For additional flexibility, see `PythonStringLambda`.
+///
+/// Secondly, note that creating a lambda will cause a (small) memory leak. In the *vast* majority of cases, the memory used by a lambda is so small (a few bytes) it's not worth being concerned about.  Where you are concerned about memory leaks, however, eg for large numbers of lambda calls in a loop, there are two solutions:
+/// 1. Create the lambda as a named variable before the loop; and then call `dealloc` on the variable afterwards. Eg:
+///
+///
+///        let tripler = 𝝺{x in x*3}  // nb: creating 𝝺 causes a leak
+///        for _ in 1...1000 {   df.apply( tripler )  }
+///        tripler.dealloc() // stop the leak 🚰
+///
+/// 2. Use the auto-deallocating function `withDeallocating`, or the equivalent custom operator `>>>`. This allows you to create and apply a lambda to a closure, and automatically deallocates it the lambda once the closure has executed. For example:
+///
+///
+///        for _ in 1...1000 {
+///            𝝺{ Int($0) } >>> { m in Python.map(m , [3.4, 2.4, 1.2] )  }
+///        }
+///
+///
+///  or exactly equivalently, but without the custom operator and the 𝝺 character:
+///
+///
+///        for _ in 1...1000 {
+///            withDeallocating( PythonLambda{ Int($0) }, in: { m in Python.map(m , [3.4, 2.4, 1.2] )  } )
+///        }
+///
+/// Lastly, note that creation of lambdas is *not* thread-safe. Lambdas are created directly into the
+/// Python runtime and given a unique identifier. Multi-threading may interrupt the creation of this
+/// unique identifier. If you create lambdas on multiple threads you need to synchronize them to ensure
+/// the identifier remains unique.
+///
+public typealias 𝝺 = PythonLambda
+
+/// Allows Swift functions to be represented as Python lambdas. Note that you can use the typealias 𝝺 for `PythonLambda`, as per this documentation, because it looks nice.
+///
+/// Example:
+///
+/// The Python code `map(lambda(x:x*2), [10,12,14] )`  would be written as:
+///
+///         Python.map( 𝝺{x in x*2} , [10,12,14] ) // [20,24,28]
+///
+///
+/// or alternatively, without the special character:
+///
+///         Python.map( PythonLambda {x in x*2} , [10,12,14] ) // [20,24,28]
+///
+///
+/// There are a number of limitations, not least that only a select number of one-parameter function shapes are supported. These are:
+/// - (Int) -> Int
+/// - (String) -> String
+/// - (String) -> Int
+/// - (Int) -> String
+/// - (Double) -> Double
+/// - (Double) -> Int
+/// - (Double) -> String
+/// - (Int) -> Bool
+/// - (String) -> Bool
+/// - (Double) -> Bool
+/// - (Bool) -> Int
+/// - (Bool) -> String
+/// - (Bool) -> Double
+/// - (Bool) -> Bool
+/// - (PythonObject) -> String
+/// - (PythonObject) -> Int
+/// - (PythonObject) -> Double
+/// - (PythonObject) -> Bool
+/// - (PythonObject) -> PythonObject
+/// - (PythonObject, PythonObject) -> PythonObject
+/// - (PythonObject, PythonObject, PythonObject) -> PythonObject
+///
+///
+/// For additional flexibility, see `PythonStringLambda`.
+///
+/// Secondly, note that creating a lambda will cause a (small) memory leak. In the *vast* majority of cases, the memory used by a lambda is so small (a few bytes) it's not worth being concerned about. However, where you are concerned about memory leaks, eg for large numbers of lambda calls in a loop, there are two solutions:
+/// 1. Create the lambda as a named variable before the loop; and then call `dealloc` on the variable afterwards. Eg:
+///
+///
+///        let tripler = 𝝺{x in x*3}  // nb: creating 𝝺 causes a leak
+///        for _ in 1...1000 {   df.apply( tripler )  }
+///        tripler.dealloc() // stop the leak 🚰
+///
+/// 2. Use the auto-deallocating function `withDeallocating`, or the equivalent custom operator `>>>`. This allows you to create and apply a lambda to a closure, and automatically deallocates it the lambda once the closure has executed. For example:
+///
+///
+///        𝝺{ Int($0) } >>> { m in Python.map(m , [3.4, 2.4, 1.2] )  }
+///
+///
+///  or exactly equivalently, but without the custom operator and the 𝝺 character:
+///
+///
+///       withDeallocating( PythonLambda{ Int($0) }, in: { m in Python.map(m , [3.4, 2.4, 1.2] )  } )
+///
+///
+///
+/// Lastly, note that creation of lambdas is *not* thread-safe. Lambdas are created directly into the
+/// Python runtime and given a unique identifier. Multi-threading may interrupt the creation of this
+/// unique identifier. If you create lambdas on multiple threads you need to synchronize them to ensure
+/// the identifier remains unique.
+///
+public class PythonLambda {
+    let backend: PythonLambdaSupport
+    public let py: PythonObject
+    private static var lambdaCounter = 0
+    
+    public init( _ fn: @escaping (Int) -> Int) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        self.backend = PythonLambdaSupport(fn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (String) -> String) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (String) -> Int) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Int) -> String) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    
+    public init( _ fn: @escaping (Double) -> Double) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Double) -> Int) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Double) -> String) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        self.backend = PythonLambdaSupport(fn, name: name)
+        
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Int) -> Bool) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+            
+        self.backend = PythonLambdaSupport(fn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (String) -> Bool) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        self.backend = PythonLambdaSupport(fn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Double) -> Bool) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+
+        self.backend = PythonLambdaSupport(fn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Bool) -> Int) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { i in
+            fn( i == 0 ? false : true)
+        }
+            
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Bool) -> Bool) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { i in
+            fn( i == 0 ? false : true)
+        }
+            
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Bool) -> String) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { i in
+            fn( i == 0 ? false : true)
+        }
+            
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (Bool) -> Double) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { i in
+            fn( i == 0 ? false : true)
+        }
+            
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (PythonObject) -> Int) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { pop in
+            fn(PythonObject(PyReference(pop)))
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (PythonObject) -> String) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { pop in
+            fn(PythonObject(PyReference(pop)))
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (PythonObject) -> Double) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { pop in
+            fn(PythonObject(PyReference(pop)))
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (PythonObject) -> Bool) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { pop in
+            fn(PythonObject(PyReference(pop)))
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+
+    public init( _ fn: @escaping (PythonObject) -> PythonObject) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { pop in
+            fn(PythonObject(PyReference(pop))).checking.ownedPyObject
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+    public init( _ fn: @escaping (PythonObject, PythonObject) -> PythonObject) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { popA, popB in
+            fn(PythonObject(PyReference(popA)),PythonObject( PyReference(popB) )).checking.ownedPyObject
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+
+    public init( _ fn: @escaping (PythonObject, PythonObject, PythonObject) -> PythonObject) {
+        let name = "lmb\(Self.lambdaUniqueName())"
+        
+        let pfn = { popA, popB, popC in
+            fn(PythonObject(PyReference(popA)),PythonObject( PyReference(popB) ),PythonObject( PyReference(popC) )).checking.ownedPyObject
+        }
+        
+        self.backend = PythonLambdaSupport(pfn, name: name)
+        self.py = PythonObject(self.backend.lambdaPointer )
+    }
+    
+     private static func lambdaUniqueName() -> String {
+        lambdaCounter += 1
+         return "\(lambdaCounter)"
+     }
+    
+    /// PythonLambda can't clean up memory properly thanks to the Swift/Python interface
+    /// By default it leaks a small amount... 'dealloc' allows you to clean up "named" lambdas.
+    /// For "unnamed" lambdas, you may wish to use With𝝺 { } { }   instead.
+    public func dealloc() {
+        self.backend.dealloc()
+    }
+}
+
+
+extension PythonLambda : PythonConvertible {
+    public var pythonObject: PythonObject {
+        _ = Python // Ensure Python is initialized.
+        return self.py
+    }
+}
+
+/// Helper struct to encapsulate the deallocation of a lambda
+private struct PythonLambdaApplication {
+    let lambda: 𝝺
+    let receiving: (𝝺) -> PythonObject
+    
+    public init(_ lambda:𝝺, to receiving: @escaping (𝝺) -> PythonObject) {
+        self.lambda = lambda
+        self.receiving = receiving
+    }
+    
+    public func exec() -> PythonObject {
+        let result = receiving(lambda)
+        lambda.dealloc()
+        return result
+    }
+}
+
+infix operator >>>
+
+/// Operator which scopes a lambda function to the closure which uses it, ensuring that the lambda is deallocated automatically.
+///
+/// - Example:
+///
+///       𝝺{ Int($0) } >>> { m in Python.map(m , [3.4, 2.4, 1.2] )  }
+/// Will create a lambda function `{ Int($0) } `  and then apply it to the code in the the closure `{ m in Python.map(m , [3.4, 2.4, 1.2] )  }`.  Once the closure executes, the lambda will be deallocated.
+/// - See Also: `withDeallocating` which is the same functionality but without the custom operator.
+public func >>>(lambda:𝝺, receiving: @escaping (𝝺) -> PythonObject) -> PythonObject {
+    return PythonLambdaApplication(lambda, to: receiving).exec()
+}
+
+/// Scopes a lambda function to the closure which uses it, ensuring that the lambda is deallocated automatically.
+///
+/// - Example
+///
+///          withDeallocating( PythonLambda{ Int($0) }, in: { m in Python.map(m , [3.4, 2.4, 1.2] )  } )
+/// Will create a lambda function `{ Int($0) } `  and then apply it to the code in the the closure `{ m in Python.map(m , [3.4, 2.4, 1.2] )  }`.  Once the closure executes, the lambda will be deallocated.
+/// - See Also: `>>>` which is the same functionality but with a  custom operator.
+public func withDeallocating(_ lambda:PythonLambda, in receiving: @escaping (PythonLambda) -> PythonObject) -> PythonObject {
+    return PythonLambdaApplication(lambda, to: receiving).exec()
+}

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -23,6 +23,8 @@ import MSVCRT
 import WinSDK
 #endif
 
+import PythonLambdaSupport
+
 //===----------------------------------------------------------------------===//
 // The `PythonLibrary` struct that loads Python symbols at runtime.
 //===----------------------------------------------------------------------===//
@@ -53,6 +55,8 @@ public struct PythonLibrary {
                 "Loaded legacy Python library, using legacy symbols...")
         }
         PythonLibrary.librarySymbolsLoaded = true
+        
+        PythonLambdaSupport.initialise(withLibrary: pythonLibraryHandle)
     }
     
     static func loadSymbol(

--- a/PythonKit/PythonStringLambda.swift
+++ b/PythonKit/PythonStringLambda.swift
@@ -1,0 +1,75 @@
+//
+//  PythonStringLambda.swift
+//  PythonKit
+//
+//  Created by strictlyswift on 2-Jul-20.
+//
+
+/// Represents an executable python lambda as a string.
+///
+/// The string is Python code which is executed as a lambda.
+/// The lambda is converted into a `PythonObject` via `.pythonObject`
+///
+/// Use this as a 'break glass' when you can't create a suitable function using the `PythonLambda` capability.
+///
+///  - Example:
+///
+///        let doubler = PythonStringLambda(lambda: "x:x*2")
+///        df.apply( doubler.py )
+///
+///  - Note: This is not thread safe and operates by creating the lambda in the `__main__` module, with a unique name.
+public class PythonStringLambda : PythonConvertible {
+    static let main: PythonObject = Python.import("__main__")
+    static var lambdaCounter = 0
+    private var id: String? = nil
+    private let lambda: String
+    
+    public init(lambda: String) {
+        if lambda.starts(with: "lambda") {
+            fatalError("Lambda expression must not start 'lambda'. Eg, just 'x:x*3')")
+        }
+        if !lambda.contains(":") {
+            fatalError("Lambda expression must contain ':' to indicate bound variables (eg 'x:x*3'")
+        }
+        self.lambda = lambda
+    }
+    
+    /// returns an executable object (not the result of the execution)
+    public var pythonObject: PythonObject { get {
+        if let id = id {
+            return Self.main[dynamicMember: id]
+        } else {
+            id = "lmbstr\(Self.lambdaCounter)"
+            PyRun_SimpleString(
+            """
+            \(id!) = lambda \(lambda)
+            """)
+            
+            Self.lambdaCounter += 1
+            return Self.main[dynamicMember: id!]
+        }
+    }}
+}
+
+
+extension PythonInterface {
+    /// Executes Python code directly in the Python interpreter. Useful to (for example) define a function to
+    /// call as a lambda later.
+    ///
+    /// Use at your own risk! Errors must be handled in Python, otherwise they are likely to simply crash your Swift code.
+    ///
+    /// - Example:
+    ///
+    ///       Python.execute("""
+    ///           def add5(i):
+    ///               return (i+5)
+    ///       """)
+    ///       let fiveAdder = PythonStringLambda(lambda: "i:add5(i)")
+    ///       Python.map( fiveAdder , [10,12,14] )   // [15,17,19]
+    public func execute(_ code: String) {
+        PyRun_SimpleString(
+        """
+        \(code)
+        """)
+    }
+}

--- a/Sources/PythonLambdaSupport/PythonLambdaSupport.swift
+++ b/Sources/PythonLambdaSupport/PythonLambdaSupport.swift
@@ -1,0 +1,737 @@
+import libpylamsupport
+
+
+let METH_VARARGS  = Int32(0x0001)
+typealias PyObjectPointer = UnsafeMutableRawPointer
+/// Allows Swift functions to be represented as Python lambdas.
+///
+/// There are a number of limitations, not least that only a limited number of function shapes are supported. These are:
+/// - (Int) -> Int
+/// - (String) -> String
+/// - (String) -> Int
+/// - (Int) -> String
+/// - (Double) -> Double
+/// - (Int) -> Bool
+/// - (String) -> Bool
+/// - (Double) -> Bool
+/// - (Bool) -> Int
+/// - (Bool) -> String
+/// - (Bool) -> Double
+/// - (Bool) -> Bool
+/// - (PythonObject) -> String
+/// - (PythonObject) -> Int
+/// - (PythonObject) -> Double
+/// - (PythonObject) -> Bool
+/// - (PythonObject) -> PythonObject
+/// - (PythonObject,PythonObject) -> PythonObject
+/// - (PythonObject,PythonObject,PythonObject) -> PythonObject
+///
+/// For additional flexibility, see `PythonStringLambda`.
+///
+///
+public class PythonLambdaSupport {
+    internal static var lambdaIntIntMap: [String: (Int) -> Int] = [:]
+    internal static var lambdaStringStringMap: [String:  (String) -> String] = [:]
+    internal static var lambdaStringIntMap: [String: (String) -> Int] = [:]
+    internal static var lambdaIntStringMap: [String: (Int) -> String] = [:]
+    internal static var lambdaDoubleDoubleMap: [String:  (Double) -> Double] = [:]
+    internal static var lambdaDoubleIntMap: [String:  (Double) -> Int] = [:]
+    internal static var lambdaStringBoolMap: [String:  (String) -> Bool] = [:]
+    internal static var lambdaIntBoolMap: [String:  (Int) -> Bool] = [:]
+    internal static var lambdaDoubleBoolMap: [String:  (Double) -> Bool] = [:]
+    internal static var lambdaObjectBoolMap: [String:  (PyObjectPointer) -> Bool] = [:]
+    internal static var lambdaDoubleStringMap: [String:  (Double) -> String] = [:]
+    internal static var lambdaIntDoubleMap: [String:  (Int) -> Double] = [:]
+    internal static var lambdaObjectObjectMap: [String:  (PyObjectPointer) -> PyObjectPointer] = [:]
+    internal static var lambdaObjectObjectObjectMap: [String:  (PyObjectPointer,PyObjectPointer) -> PyObjectPointer] = [:]
+    internal static var lambdaObjectObjectObjectObjectMap: [String:  (PyObjectPointer,PyObjectPointer,PyObjectPointer) -> PyObjectPointer] = [:]
+    internal static var lambdaObjectStringMap: [String:  (PyObjectPointer) -> String] = [:]
+    internal static var lambdaObjectDoubleMap: [String:  (PyObjectPointer) -> Double] = [:]
+    internal static var lambdaStringObjectMap: [String:  (String) -> PyObjectPointer] = [:]
+    internal static var lambdaObjectIntMap: [String:  (PyObjectPointer) -> Int] = [:]
+
+    public static func initialise( withLibrary lib: UnsafeMutableRawPointer) {
+        initialisePythonLibrary(lib)
+    }
+    
+    
+    private let name: String // MUST be unique
+    private var methodDef: UnsafeMutablePointer<PyMethodDef>
+    private let pythonLambda: PyObjectPointer
+    
+    public init( _ fn: @escaping (Int) -> Int, name: String) {
+        self.name = name
+        self.methodDef = Self.methodDefFor(
+            name: name,
+            method: pyIntIntCaller
+        )
+        self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+        Self.lambdaIntIntMap[name] = fn
+    }
+    
+    public init( _ fn: @escaping (String) -> String, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyStringStringCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaStringStringMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (String) -> Int, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyStringIntCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaStringIntMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Int) -> String, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyIntStringCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaIntStringMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Double) -> Double, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyDoubleDoubleCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaDoubleDoubleMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Double) -> Int, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyDoubleIntCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaDoubleIntMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Int) -> Bool, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyIntBoolCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaIntBoolMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (String) -> Bool, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyStringBoolCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaStringBoolMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Double) -> Bool, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyDoubleBoolCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaDoubleBoolMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer) -> Bool, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectBoolCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectBoolMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Double) -> String, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyDoubleStringCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaDoubleStringMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (Int) -> Double, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyIntDoubleCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaIntDoubleMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer) -> Int, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectIntCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectIntMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer) -> UnsafeMutableRawPointer, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectObjectCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectObjectMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer,UnsafeMutableRawPointer) -> UnsafeMutableRawPointer, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectObjectObjectCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectObjectObjectMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer,UnsafeMutableRawPointer,UnsafeMutableRawPointer) -> UnsafeMutableRawPointer, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectObjectObjectObjectCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectObjectObjectObjectMap[name] = fn
+     }
+    
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer) -> String, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectStringCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectStringMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (UnsafeMutableRawPointer) -> Double, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyObjectDoubleCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaObjectDoubleMap[name] = fn
+     }
+    
+    public init( _ fn: @escaping (String) -> UnsafeMutableRawPointer, name: String) {
+         self.name = name
+         self.methodDef = Self.methodDefFor(
+             name: name,
+             method: pyStringObjectCaller
+         )
+         self.pythonLambda = Self.lambdaBuilder(methodDefPtr: self.methodDef, name: name)
+
+         Self.lambdaStringObjectMap[name] = fn
+     }
+    
+    private static func methodDefFor( name: String,
+                              method: PyCFunction?) -> UnsafeMutablePointer<PyMethodDef> {
+        name.utf8CString.withUnsafeBufferPointer { namePtr in
+            let methodDef = PyMethodDef(
+                ml_name:  namePtr.baseAddress,
+                ml_meth: method,
+                ml_flags: METH_VARARGS,
+                ml_doc: namePtr.baseAddress
+            )
+            
+            return withUnsafePointer(to: methodDef) { methodDefPtr in
+            // we take a copy of the method definition, because otherwise Swift will
+            // deallocate it for us when the PythonLambda goes out of scope
+            // this is a memory leak
+                let fnDef = UnsafeMutablePointer<PyMethodDef>.allocate(capacity: 1)
+                fnDef.assign(from: methodDefPtr, count: 1)
+                
+                return fnDef
+            }
+        }
+        
+
+    }
+    
+    private static func lambdaBuilder( methodDefPtr: UnsafeMutablePointer<PyMethodDef>, name: String) -> PyObjectPointer {
+        name.utf8CString.withUnsafeBufferPointer { namePtr in
+            let pop = createPyCFunction(methodDefPtr, getPyUnicode_FromString(namePtr.baseAddress))
+            return UnsafeMutableRawPointer(pop!)
+        }
+    }
+
+    public var lambdaPointer: UnsafeMutableRawPointer {
+        get { return pythonLambda }
+    }
+    
+    /// Deallocate a lambda function. This has to be done manually.
+    public func dealloc() {
+        self.methodDef.deallocate()
+        
+        // Remove dictionary entries. NB only one of these should  actually have an entry as the name should
+        // be unique!
+        Self.lambdaIntIntMap[self.name] = nil
+        Self.lambdaStringStringMap[self.name] = nil
+        Self.lambdaStringIntMap[self.name] = nil
+        Self.lambdaIntStringMap[self.name] = nil
+        Self.lambdaDoubleDoubleMap[self.name] = nil
+        Self.lambdaDoubleIntMap[self.name] = nil
+        Self.lambdaStringBoolMap[self.name] = nil
+        Self.lambdaIntBoolMap[self.name] = nil
+        Self.lambdaDoubleBoolMap[self.name] = nil
+        Self.lambdaObjectBoolMap[self.name] = nil
+        Self.lambdaDoubleStringMap[self.name] = nil
+        Self.lambdaIntDoubleMap[self.name] = nil
+        Self.lambdaObjectObjectMap[self.name] = nil
+        Self.lambdaObjectObjectObjectMap[self.name] = nil
+        Self.lambdaObjectObjectObjectObjectMap[self.name] = nil
+        Self.lambdaObjectStringMap[self.name] = nil
+        Self.lambdaObjectDoubleMap[self.name] = nil
+        Self.lambdaStringObjectMap[self.name] = nil
+        Self.lambdaObjectIntMap[self.name] = nil
+    }
+    
+    deinit {
+    }
+}
+
+
+// has to be at top level so we can get C function pointer to it
+func pyIntIntCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaIntIntMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToLongInt(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapLongInt(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyIntStringCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaIntStringMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToLongInt(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapString(newV)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyIntBoolCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaIntBoolMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToLongInt(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapBool(newV ? 1 : 0)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyDoubleDoubleCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaDoubleDoubleMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToDouble(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapDouble(newV)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyIntDoubleCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaIntDoubleMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToLongInt(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapDouble(newV)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyDoubleIntCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaDoubleIntMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToDouble(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapLongInt(newV)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyDoubleBoolCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaDoubleBoolMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToDouble(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapBool(newV ? 1 : 0)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyDoubleStringCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaDoubleStringMap[lambdaName] {
+            var error = 0
+            let v = parseArgsToDouble(args, &error)
+            if error != 0 {
+                let newV = fn(v)
+                return wrapString(newV)
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyStringIntCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaStringIntMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToString(args, &error),
+                error != 0 {
+                let newV = fn(String(cString: v))
+                let iPointer = wrapLongInt(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyStringBoolCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaStringBoolMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToString(args, &error),
+                error != 0 {
+                let newV = fn(String(cString: v))
+                let iPointer = wrapBool(newV ? 1 : 0)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+
+func pyStringStringCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaStringStringMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToString(args, &error),
+                error != 0 {
+                let newV = fn(String(cString: v))
+                let iPointer = wrapString(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectIntCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectIntMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToObject(args, &error),
+                error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapLongInt(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectBoolCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectBoolMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToObject(args, &error),
+                error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapBool(newV ? 1 : 0)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectStringCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectStringMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToObject(args, &error),
+                error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapString(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectDoubleCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectDoubleMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToObject(args, &error),
+                error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapDouble(newV)
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectObjectCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectObjectMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToObject(args, &error),
+                error != 0 {
+                let newV = fn(v)
+                let iPointer = wrapObject(newV.assumingMemoryBound(to: PyObject.self))
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectObjectObjectCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectObjectObjectMap[lambdaName] {
+            var error = 0
+            var objectB: UnsafeMutablePointer<PyObject>?
+            if let v = parseArgsToObjectPair(args, &objectB, &error),
+                let objectB = objectB,
+                error != 0 {
+                let newV = fn(v,objectB)
+                let iPointer = wrapObject(newV.assumingMemoryBound(to: PyObject.self))
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyObjectObjectObjectObjectCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaObjectObjectObjectObjectMap[lambdaName] {
+            var error = 0
+            var objectB: UnsafeMutablePointer<PyObject>?
+            var objectC: UnsafeMutablePointer<PyObject>?
+            if let v = parseArgsToObjectTriple(args, &objectB, &objectC, &error),
+                let objectB = objectB,
+                let objectC = objectC,
+                error != 0 {
+                let newV = fn(v,objectB,objectC)
+                let iPointer = wrapObject(newV.assumingMemoryBound(to: PyObject.self))
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}
+
+func pyStringObjectCaller(sself:UnsafeMutablePointer<PyObject>?,
+              args: UnsafeMutablePointer<PyObject>?)
+    -> UnsafeMutablePointer<PyObject>? {
+        guard let lambdaNamePtr = sself else { return nil }
+        let lambdaName = String(cString: stringFromPythonObject(lambdaNamePtr))
+        
+        if let fn = PythonLambdaSupport.lambdaStringObjectMap[lambdaName] {
+            var error = 0
+            if let v = parseArgsToString(args, &error),
+                error != 0 {
+                let newV = fn(String(cString: v))
+                let iPointer = wrapObject(newV.assumingMemoryBound(to: PyObject.self))
+                return iPointer
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+}

--- a/Sources/libpylamsupport/LambdaBuilder.c
+++ b/Sources/libpylamsupport/LambdaBuilder.c
@@ -1,0 +1,182 @@
+//
+//  LambdaBuilder.c
+//  DataFrame
+//
+//  Created by RedPanda on 2-Jul-20.
+//  Copyright © 2020 strictlyswift. All rights reserved.
+//
+
+#include "include/LambdaBuilder.h"
+#include <dlfcn.h>
+
+static void* _pythonLibraryHandle;
+int (*pyarg_parsetuple)(PyObject *args, const char *format, ...);
+PyObject* (*py_buildvalue)(const char *format, ...);
+const char* (*pyunicode_asutf8)(PyObject*);
+PyObject* (*pyunicode_fromstring)(const char*);
+PyObject* (*py_createPyCFunction)(PyMethodDef*, PyObject*, PyObject*);
+PyObject* (*py_boolfromlong)(long v);
+
+int initialisePythonLibrary(void* libraryHandle) {
+    _pythonLibraryHandle = libraryHandle;
+#ifdef _WIN32
+    pyarg_parsetuple = GetProcAddress((HINSTANCE__)libraryHandle,"PyArg_ParseTuple");
+    py_buildvalue = GetProcAddress((HINSTANCE__)libraryHandle, "Py_BuildValue");
+    pyunicode_asutf8 = GetProcAddress((HINSTANCE__)libraryHandle, "PyUnicode_AsUTF8");
+    pyunicode_fromstring = GetProcAddress((HINSTANCE__)libraryHandle, "PyUnicode_FromString");
+    py_boolfromlong = GetProcAddress((HINSTANCE__)libraryHandle, "PyBool_FromLong");
+    py_createPyCFunction = GetProcAddress((HINSTANCE__)libraryHandle, "PyCFunction_NewEx");
+#else
+    pyarg_parsetuple = dlsym(_pythonLibraryHandle, "PyArg_ParseTuple");
+    py_buildvalue = dlsym(_pythonLibraryHandle, "Py_BuildValue");
+    pyunicode_asutf8 = dlsym(_pythonLibraryHandle, "PyUnicode_AsUTF8");
+    pyunicode_fromstring = dlsym(_pythonLibraryHandle, "PyUnicode_FromString");
+    py_boolfromlong = dlsym(_pythonLibraryHandle, "PyBool_FromLong");
+    py_createPyCFunction = dlsym(_pythonLibraryHandle, "PyCFunction_NewEx");
+#endif
+}
+
+char* parseArgsToString(PyObject *args, long int *error) {
+    char* value;
+    int result = (*pyarg_parsetuple)(args, "s", &value);
+    
+    *error = result;
+    return value;
+}
+
+double parseArgsToDouble(PyObject *args, long int *error) {
+    double value;
+    int result = (*pyarg_parsetuple)(args, "d", &value);
+    
+    *error = result;
+    return value;
+}
+
+
+long int parseArgsToLongInt(PyObject *args, long int *error) {
+    long int value;
+    int result = (*pyarg_parsetuple)(args, "l", &value);
+    
+    *error = result;
+    return value;
+}
+
+PyObject* parseArgsToObject(PyObject *args, long int *error) {
+   PyObject* value;
+    int result = (*pyarg_parsetuple)(args, "O", &value);
+    
+    *error = result;
+    return value;
+}
+
+PyObject* parseArgsToObjectPair(PyObject *args, PyObject **objectB, long int *error) {
+    PyObject* valueA;
+    PyObject* valueB;
+    int result = (*pyarg_parsetuple)(args, "OO", &valueA, &valueB);
+    
+    *error = result;
+    *objectB = valueB;
+    return valueA;
+}
+
+PyObject* parseArgsToObjectTriple(PyObject *args, PyObject **objectB, PyObject **objectC,  long int *error) {
+    PyObject* valueA;
+    PyObject* valueB;
+    PyObject* valueC;
+    int result = (*pyarg_parsetuple)(args, "OOO", &valueA, &valueB, &valueC);
+    
+    *error = result;
+    *objectB = valueB;
+    *objectC = valueC;
+    return valueA;
+}
+
+PyObject* wrapLongInt(long int value) {
+    PyObject* pyValue = (*py_buildvalue)("l",value);
+    return pyValue;
+}
+
+PyObject* wrapString(const char* value) {
+    PyObject* pyValue = (*py_buildvalue)("s",value);
+    return pyValue;
+}
+
+PyObject* wrapDouble(double value) {
+    PyObject* pyValue = (*py_buildvalue)("d",value);
+    return pyValue;
+}
+
+PyObject* wrapObject(PyObject* value) {
+    PyObject* pyValue = (*py_buildvalue)("O",value);
+    return pyValue;
+}
+
+PyObject* wrapBool(long int value) {
+    PyObject* pyValue = (*py_boolfromlong)(value);
+    return pyValue;
+}
+/*
+PyObject* createModuleFunc(PyMethodDef* methodDef, const char* name) {
+    const char *mymodule = "__builtin__";
+  //  void *pyLib = dlopen("/Library/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib", RTLD_LAZY | RTLD_GLOBAL);
+    
+    PyObject* (*pyCFunctionNewEx)(PyMethodDef*, PyObject*, PyObject*) = dlsym(pythonLibraryHandle, "PyCFunction_NewEx");
+    
+    PyObject* (*pyStringFromString)(const char *)  = dlsym(pythonLibraryHandle, "PyUnicode_FromString");
+    
+    PyObject* (*importModule)(const char*)  = dlsym(pythonLibraryHandle, "PyImport_ImportModule");
+    
+    PyObject* (*moduleGetDict)(PyObject*)  = dlsym(pythonLibraryHandle, "PyModule_GetDict");
+    
+    int (*dictSetItemString)(PyObject*, const char *, PyObject*) = dlsym(pythonLibraryHandle, "PyDict_SetItemString");
+    
+  //  PyObject* usrPtr = (*pyStringFromString)(name);
+    PyObject* modname = (*pyStringFromString)("builtins");
+    
+    PyObject* methodName = (*pyStringFromString)(name);
+
+    PyObject* mod = (*importModule)("builtins");
+    PyObject* dict = (*moduleGetDict)(mod);
+
+    
+    PyObject* fnc = (*pyCFunctionNewEx)(methodDef, methodName, modname);
+    
+    (*dictSetItemString)(dict, name, fnc);
+    
+    return fnc;
+
+}
+*/
+const char* stringFromPythonObject(PyObject* p) {
+    return (*pyunicode_asutf8)(p);
+}
+/*
+PyCFunction copyPyCFnPtr(PyCFunction p) {
+    PyCFunction newPtr = (PyCFunction) malloc(sizeof(PyCFunction));
+    memcpy(newPtr, p, sizeof(PyCFunction));
+    return newPtr;
+}
+*/
+PyObject * getPyUnicode_FromString (const char *u) {
+    if (pyunicode_fromstring == NULL) {
+        printf("Lambda functions not available on Python 2!\n");
+        exit(1);
+    }
+    return (*pyunicode_fromstring)(u);
+}
+
+PyObject* createPyCFunction(PyMethodDef* ml, PyObject* data) {
+    return (*py_createPyCFunction)(ml, data, NULL);
+}
+
+void debug_showAddress(const char* varName, void* value) {
+    printf("variable %s has value %#llx\n", varName, (unsigned long long)value);
+}
+
+//PyObject* addFunction(PyMethodDef *method, PyObject* callback) {
+//    return (void*)PyCFunction_New(method, NULL);
+//    //return PyCFunction_New(&donothing_ml, NULL);
+//}
+
+// see here
+// https://docs.python.org/2.7//extending/extending.html#calling-pythong-functions-from-c

--- a/Sources/libpylamsupport/include/LambdaBuilder.h
+++ b/Sources/libpylamsupport/include/LambdaBuilder.h
@@ -1,0 +1,38 @@
+//
+//  LambdaBuilder.h
+//  DataFrame
+//
+//  Created by RedPanda on 2-Jul-20.
+//  Copyright © 2020 strictlyswift. All rights reserved.
+//
+
+#ifndef LambdaBuilder_h
+#define LambdaBuilder_h
+
+#include <stdio.h>
+#include <Python/Python.h>
+int initialisePythonLibrary(void* libraryHandle);
+
+long int parseArgsToLongInt(PyObject *args, long int *error);
+char* parseArgsToString(PyObject *args, long int *error);
+PyObject* parseArgsToObject(PyObject *args, long int *error);
+double parseArgsToDouble(PyObject *args, long int *error);
+PyObject* parseArgsToObjectPair(PyObject *args, PyObject **objectB, long int *error);
+PyObject* parseArgsToObjectTriple(PyObject *args, PyObject **objectB, PyObject **objectC,  long int *error);
+
+PyObject* wrapLongInt(long int value);
+PyObject* wrapString(const char* value);
+PyObject* wrapObject(PyObject* value);
+PyObject* wrapDouble(double value);
+PyObject* wrapBool(long int value);
+
+// Shims for useful Python library functions
+//PyCFunction copyPyCFnPtr(PyCFunction p);
+//PyObject* createModuleFunc(PyMethodDef* methodDef, const char* name);
+const char* stringFromPythonObject(PyObject* p);
+PyObject * getPyUnicode_FromString (const char *u);
+PyObject* createPyCFunction(PyMethodDef* ml, PyObject* data);
+
+void debug_showAddress(const char* varName, void* value);
+
+#endif /* LambdaBuilder_h */

--- a/Tests/PythonKitTests/PythonLambdaTests.swift
+++ b/Tests/PythonKitTests/PythonLambdaTests.swift
@@ -1,0 +1,99 @@
+//
+//  PythonLambdaTests.swift
+//  
+//
+
+import XCTest
+import PythonKit
+
+class PythonLambdaTests: XCTestCase {
+    let pmap = Python.map
+    let plist = Python.list
+    
+    func testCheckVersion() {
+        XCTAssertGreaterThanOrEqual(Python.versionInfo.major, 3)
+        XCTAssertGreaterThanOrEqual(Python.versionInfo.minor, 7)
+    }
+    
+    func testIntIntLambda() {
+        let doubled = plist(pmap( 𝝺{x in x*2},  [-1, 20, 8] ))
+        XCTAssertEqual(Array<Int>(doubled), [-2, 40, 16])
+    }
+    
+    func testIntBoolLambda() {
+        let even = plist(pmap( 𝝺{(x:Int) in x.isMultiple(of: 3) ? true : false},  [45, 56, 63] ))
+        XCTAssertEqual(Array<Bool>(even) , [true, false, true])
+    }
+    
+    func testIntStringLambda() {
+        let strs = plist(pmap( 𝝺{(x:Int) in "\(x)"},  [-2,-3,100] ))
+        XCTAssertEqual(Array<String>(strs), ["-2", "-3", "100"])
+    }
+    
+    func testObjectStringLambda() {
+        let strs = plist(pmap( 𝝺{(x:PythonObject) in "\(x)!!"},  PythonObject(["a", 2, true, 1.5] )))
+        
+        XCTAssertEqual(Array<String>(strs)!, ["a!!","2!!","True!!","1.5!!"])
+    }
+    
+    func testBoolBoolLambda() {
+        let bools = plist(pmap( 𝝺{x in !x},  [true, false, true] ))
+        XCTAssertEqual(Array<Bool>(bools), [false, true, false])
+    }
+    
+    func testObjectObjectLambda() {
+        let objArray = plist(pmap( 𝝺{(x:PythonObject) in PythonObject([x])},  PythonObject(["a", 2, true, 1.5] )))
+        XCTAssertEqual(["a"], objArray[0])
+        XCTAssertEqual([2], objArray[1])
+        XCTAssertEqual([true], objArray[2])
+        XCTAssertEqual([1.5], objArray[3])
+    }
+    
+    func testObjectObject_to_ObjectLambda() {
+        let functools = Python.import("functools")
+        let preduce = functools[dynamicMember: "reduce"]
+        let nums = PythonObject([1,2,3,4,5])
+        let reducer = 𝝺 { (x:PythonObject,y:PythonObject) -> PythonObject in PythonObject(Int(x)!+Int(y)!)  }
+        
+        let result = preduce( reducer, nums )
+        
+        XCTAssertEqual(15, Int(result)!)
+    }
+    
+    func testLambdaDealloc() {
+        let tripler = 𝝺{x in x*3}
+        let tripled = plist(pmap( tripler,  [-1, 20, 8] ))
+        tripler.dealloc()
+        XCTAssertEqual(Array<Int>(tripled), [-3, 60, 24])
+
+    }
+
+    func testAutoDeallocatingLambdas() {
+        var countRets = 0
+        for _ in 1...10000 {
+            // the count is to make sure the compiler doesn't try to cleverly optimize this away
+            countRets += (𝝺{ Int($0) } >>> { l in self.plist(self.pmap(l , [3.4, 2.4, 1.2] ))  }).count
+        }
+        
+        XCTAssertEqual(countRets, 30000)
+    }
+    
+    func testStringLambda() {
+        let len = PythonStringLambda(lambda: "x:len(x)")
+        let results = plist(pmap( len, ["hello","bye",""]))
+        XCTAssertEqual(results, [5, 3, 0])
+    }
+    
+    func testExecuteAndStringLambda() {
+        Python.execute("""
+        def add5(i):
+            return (i+5)
+        """)
+
+        let fiveAdder = PythonStringLambda(lambda: "i:add5(i)")
+        let added = plist(pmap( fiveAdder , [10,12,14] ) )
+        
+        XCTAssertEqual(added, [15, 17, 19])
+    }
+}
+


### PR DESCRIPTION
_This is the first time I've submitted a pull request to an open source project, so hopefully this is the right way to go about it! Please let me know if not!_

**Aim of PR**
This PR adds lambda support to PythonKit, enabling Swift functions to be used directly as lambdas in Python in a type-safe fashion.  This is extremely useful in many real-world situations of using Swift with Python, eg mapping a lambda function over a Python list, or applying a function to a Pandas dataframe (my original motivation).

**Example**
The Python code `map(lambda(x:x*2), [10,12,14] )`  could be written in Swift as:

`Python.map( PythonLambda {x in x*2} , [10,12,14] ) // [20,24,28]`

As a convenience, and to improve the look of the code, the special character 𝝺 is provided as a typealias for `PythonLambda`. So the above can be written as:

`Python.map( 𝝺{x in x*2} , [10,12,14] ) // [20,24,28]`


A second example: sum all the rows in a Pandas dataframe:
`let summer = 𝝺{(row:PythonObject) in Double(np.sum(row)) ?? 0}`
`let result = df.apply( summer, axis: 0 )`


The lambda feature is fairly comprehensive but does have some limitations, detailed below.

**Additional Features**
The PR also enables two additional features which can be useful when interfacing with Python code.

`PythonStringLambda(lambda: String) -> PythonObject`

will create a lambda directly from the Python code provided as a parameter. For example:

`let doubler = PythonStringLambda(lambda: "x:x*2")  // x*2 is interpreted as Python code`
`df.apply( doubler.py )`

For more complex use cases, it can be useful to run arbitrary Python code from Swift (eg, to define a function to be called in a lambda). The `PythonInterface` class is extended with `Python.execute` to allow this:

`Python.execute("""`
`def add5(i):`
`    return (i+5)`
`""")`

`let fiveAdder = PythonStringLambda(lambda: "i:add5(i)")`
`print( Python.list(Python.map( fiveAdder , [10,12,14] ) ) )`

Note that this interface is inherently unsafe: errors or unexpected results may crash your Swift program with Python errors.

**Limitations**
Each of these limitations are documented in the PythonLambda interface documentation.  Here is some more detail.

PythonLambda only works on Python3 and above.  (It could be fixed to work on Python2, but as that's deprecated I wasn't sure it was worthwhile.)

The PythonLambda interface only supports a limited number of mostly 1-parameter function shapes (specifically listed in the documentation). Generally as lambdas are simple functions, this is sufficient.  Two- and three-parameter "PythonObject" functions are also supported (which are essentially un-type-checked by Swift but can be used to pass more complex objects, see the Dataframe example above)

For more complex lambdas, `PythonStringLambda` can be used.


Secondly, as Python doesn't really have the notion of an "escaping" function, a small memory leak is caused whenever a lambda is created. The lambda has to be created on the heap and kept around indefinitely, as neither Swift nor Python can "know" when the lambda is finished with. The lambda  must be _manually_ deallocated (if there is a concern about memory usage: the leak per lambda creation is only a few bytes).

Where you are concerned about memory leaks, however, eg for large numbers of lambda calls in a loop, there are two solutions:
1. Create the lambda as a named variable before the loop; and then call `dealloc` on the variable afterwards. Eg:

`let tripler = 𝝺{x in x*3}  // nb: creating 𝝺 causes a leak`
`for _ in 1...1000 {   df.apply( tripler )  }`
`tripler.dealloc() // stop the leak 🚰`

2. Use the auto-deallocating function `withDeallocating`, or the equivalent custom operator `>>>`. This allows you to create and apply a lambda to a closure, and automatically deallocates it the lambda once the closure has executed. For example:

`for _ in 1...1000 {`
`    𝝺{ Int($0) } >>> { m in Python.map(m , [3.4, 2.4, 1.2] )  }`
`}`

or exactly equivalently, but without the custom operator and the 𝝺 character:

`for _ in 1...1000 {`
`    withDeallocating( PythonLambda{ Int($0) }, in: { m in Python.map(m , [3.4, 2.4, 1.2] )  } )`
`}`

Lastly, note that lambda creation is _not_ thread-safe.  Each lambda is created with a unique identifier via a simple incrementing counter: if lambda creation happens on two threads simultaneously, the unique identifier creation may get confused.



**The Files in the PR**
- `PythonKit/PythonLambda.swift` (NEW):  Provides the public-facing API.  Most of this file is initialization of various function shapes; and then calling to a back-end helper class `PythonLambdaSupport`.
- `PythonKit/PythonStringLambda.swift` (NEW): Provides the ability to execute Python code as a lambda; and extended `PythonInterface` to add `execute` as per the above.
- `PythonKit/Python.swift` (MODIFIED): Single-line addition to allow CheckingPythonObject to return its owned object -- used when converting from a function returning a PythonObjectPointer, back to a function returning a PythonObject
- `PythonKit/PythonLibrary.swift` (MODIFIED): Two-line addition to initialize the Python-C interface in LambdaBuilder.c.
- `Sources/PythonLambdaSupport/PythonLambdaSupport.swift` (NEW): Creates the lambdas via the C interface.  Each lambda is mapped to a function type via a Dictionary, this is to ensure that the arguments can be correctly extracted from the Python method-calling convention at execution-time. Again a large amount of boilerplate code to handle the different function shapes and types.
- `Sources/libpylamsupport/LambdaBuilder.c` (NEW): C file which interfaces to the Python C API. Mostly this is done in order to marshall the variadic argument functions used by the C API, as far as I can tell it's not possible to do this from Swift.
- `Sources/libpylamsupport/include/LambdaBuilder.h` (NEW): Header file for the above C file
- `Tests/PythonKitTests/PythonLambdaTests.swift` (NEW): A number of tests for the functionality

**Notes**
1. For further examples, see `PythonLambdaTests.swift`.
2. The code has only been tested on the Mac. Following the rest of the PythonKit code, I have added `#ifdef`s so it should "in theory" work on Windows and Linux, but I don't have the capability to test those builds.
3. The Sources/.. files are in this structure as that allows mixed-mode C and Swift packages. Maybe there's a better solution? Ideally all this would run from Swift, but I couldn't get the variadic call PyArg_ParseTuple and Py_BuildValue to work.