### PR TITLE
Enhance Python-C Interoperability

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -82,6 +82,11 @@ public struct PythonLibrary {
     }
 }
 
+public extension PythonLibrary {
+    /// For integration with the C Python interface
+    static var sharedPythonLibrary: UnsafeMutableRawPointer { get { PythonLibrary.shared.pythonLibraryHandle }}
+}
+
 // Methods of `PythonLibrary` required to set a given Python version.
 public extension PythonLibrary {
     static func useVersion(_ major: Int, _ minor: Int? = nil) {

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -270,4 +270,16 @@ class PythonRuntimeTests: XCTestCase {
             _ = Bool.init(b)
         }
     }
+    
+    func testGetObjectPointers() {
+        let pythonObject = PythonObject([1,"a",true])
+        let ptr = pythonObject.asUnsafePointer
+        let pyObjectFromRef = PythonObject(unsafe: ptr)
+        
+        XCTAssertEqual(pythonObject, pyObjectFromRef)
+    }
+    
+    func testLibraryHandle() {
+        XCTAssertNotNil(PythonLibrary.sharedPythonLibrary)
+    }
 }

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -282,4 +282,17 @@ class PythonRuntimeTests: XCTestCase {
     func testLibraryHandle() {
         XCTAssertNotNil(PythonLibrary.sharedPythonLibrary)
     }
+
+    func testExecute() {
+        let main = Python.import("__main__")
+        Python.execute("""
+        def add5(i):
+            return (i+5)
+        """)
+
+        let added5 = main[dynamicMember:"add5"](2)
+        
+        XCTAssertEqual(added5, 7)
+    }
+
 }


### PR DESCRIPTION
_As per the comments to PR#22, I am splitting out the Python lambda functionality into its own package. However, in order to make that work I need a few changes to the PythonKit package; I have tried to minimise them and avoid causing encapsulation issues etc.  Please let me know your thoughts_

### Aim of PR
Provides a few _public_ extension points to the Python runtime in PythonKit, to enhance interoperability with the Python-C interface.  This is to allow other packages using PythonKit to interact with Python-C  (particularly my 'PythonLambda' package, though would be usable by others).  The API changes are not intended for "general" use and hence I've tried to keep them to a minimum.

### Details of Changes
**PythonObject extensions**
`public init(unsafe pointer: UnsafeMutableRawPointer)`
- New public initializer for PythonObject, providing an `UnsafeMutableRawPointer`.  This allows a python object created from the Python-C interface to be converted into a PythonObject for use elsewhere with PythonKit.  Note that the object is not "consumed", ie its reference count is not changed.  The method's argument is tagged with `unsafe` to indicate it's not safe for general use (and indeed, care is needed – if the "real" Python object goes away, the PythonObject won't be valid anymore). This API is deliberately undocumented to discourage accidental use.

`var asUnsafePointer : UnsafeMutableRawPointer`
- the reverse operation to the above: gets a pointer to a PythonObject for use with the Python C APIs.  Again there is no ownership or reference count change; and the "unsafe" is intended to indicate this should be used with caution. This API is deliberately undocumented to discourage accidental use.

`internal var ownedPyObject: OwnedPyObjectPointer { get { base.ownedPyObject }}`
- an internal-only API addition, to implement the `asUnsafePointer` API.

**PythonInterface extension**
`public func execute(_ code: String)`
- Exposes a public API to allow arbitrary Python code to be executed from a string, by passing it to the Python runtime.  This is potentially "risky" in that incorrect Python code can cause the Swift code to crash. However, that's a general problem with the Python interface anyway, and this is occasionally the only way to access Python features from Swift – hence this is made available as a public, documented API.

**PythonLibrary extension**
`static var sharedPythonLibrary: UnsafeMutableRawPointer { get { PythonLibrary.shared.pythonLibraryHandle }}`
- Provides a handle to the Python library (dylib/dll), so that other packages can load Python library functions from the same source, without having to re-load the library themselves.  This is public but minimally documented as it's likely to be of utility only to package authors.

**Tests**
- Tests have been added to exercise the above functionality.