### PR TITLE
Allow defining Swift functions to be called from Python

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1363,7 +1363,14 @@ extension PythonObject : ExpressibleByArrayLiteral, ExpressibleByDictionaryLiter
 // PythonFunction - create functions in Swift that can be called from Python
 //===----------------------------------------------------------------------===//
 
-import Python
+typealias PyCFunction = @convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?
+
+struct PyMethodDef {
+    public var ml_name: UnsafePointer<Int8> /* The name of the built-in function/method */
+    public var ml_meth: PyCFunction /* The C function that implements it */
+    public var ml_flags: Int32 /* Combination of METH_xxx flags, which mostly describe the args expected by the C func */
+    public var ml_doc: UnsafePointer<Int8>? /* The __doc__ attribute, or NULL */
+}
 
 /// Create functions in Swift that can be called from Python
 ///
@@ -1445,7 +1452,7 @@ private extension PythonFunction {
                 let `self` = Unmanaged<PythonFunction>.fromOpaque(selfPointer).takeUnretainedValue()
 
                 // This must only be `nil` if an exception has been set (i.e. an error was thrown)
-                return self.callSwiftFunction(args)?.assumingMemoryBound(to: PyObject.self)
+                return self.callSwiftFunction(args)
         },
             ml_flags: METH_VARARGS,
             ml_doc: nil

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -19,6 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 typealias PyObjectPointer = UnsafeMutableRawPointer
+typealias PyMethodDefPointer = UnsafeMutableRawPointer
 typealias PyCCharPointer = UnsafePointer<Int8>
 typealias PyBinaryOperation =
     @convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?
@@ -54,6 +55,15 @@ let PyEval_GetBuiltins: @convention(c) () -> PyObjectPointer =
 
 let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
     PythonLibrary.loadSymbol(name: "PyRun_SimpleString")
+
+let PyCFunction_New: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer) -> PyObjectPointer =
+    PythonLibrary.loadSymbol(name: "PyCFunction_New")
+
+let PyObject_GC_UnTrack: @convention(c) (PyObjectPointer) -> Void =
+    PythonLibrary.loadSymbol(name: "PyObject_GC_UnTrack")
+
+let PyErr_SetString: @convention(c) (PyObjectPointer, UnsafePointer<CChar>?) -> Void =
+    PythonLibrary.loadSymbol(name: "PyErr_SetString")
 
 let PyErr_Occurred: @convention(c) () -> PyObjectPointer? =
     PythonLibrary.loadSymbol(name: "PyErr_Occurred")


### PR DESCRIPTION
# Motivation

We would like to create Swift functions that can be called from Python. Specifically, we want to use `optuna` to optimise some parameters going into one of our Swift functions, so it makes sense for Optuna to call our Swift callback to avoid workarounds.

We had a look at `PythonLambda` (see other open PR) and found it didn't meet our needs in terms of being able to raise Python exceptions from Swift functions. I also found it difficult to add the desired functionality to their codebase (multiple targets / repos, > 1000 lines of code, lots of repetition).

# Implementation

I created the current self-contained PR to allow the same functionality in much less code, including support for exceptions and variadic parameters, and without exposing any `PythonKit` internals.

Here is a contrived example using `optuna`, integrating example code from their website:

```
let optuna = Python.import("optuna")

let objective = PythonFunction { trial in
    let x = Float(trial.suggest_uniform("x", -5, 5))! // Optuna suggests a float in the given range
    
    // Doesn't actually make sense, just showing the possibility to throw a Python exception:
    if x > 3 || x < -3 {
        // If we were doing expensive work, ignoring this trial would save a lot of time
        throw optuna.TrialPruned()
    }

    return pow(x - 2, 2.0) // this will be optimised to be as close to 0.0 as possible
}

let study = optuna.create_study(
    pruner: optuna.pruners.MedianPruner(),
    sampler: optuna.samplers.TPESampler()
)

study.optimize(objective, n_trials: 100)
print(study.best_params) // x: ~2.00
```

At the moment there I have only implemented explicit support for functions that take a single argument:

`PythonFunction { (x: PythonObject) in x + 1 }`

or a variadic array of arguments (0, 1 or many):

`PythonFunction { (x: [PythonObject]) in print(x); return x }`

I did this deliberately to reduce API surface area to start with, but am open to feedback here as much as anywhere.

## Open issues

### Python Garbage Collection

I did run across some issues with memory management: unless we opt out of Python's garbage collection, the functions we create seem to get swept away as soon as `gc.collect()` is run manually or automatically. This causes BAD_ACCESS exceptions. There is a workaround in place that works but I'd appreciate feedback here from someone more experienced than me – maybe there is a better way.

### Swift Memory Management

I also ran into an issue with Swift memory management: we currently pass a retained reference to the `PythonFunction` instance when creating the function - this is not ideal because it means that the Swift class will also never reach a reference count of zero. If we don't do this, we get a segmentation fault when the Python function's `PyReference` is cleaned up. I'm not actually sure exactly why this happens - I think Python is trying to access our `selfPointer` after Swift has freed it.


## Summary

As it stands there are minor memory leaks involved in using this functionality. The question is: can we fix them with `PythonKit`'s current memory management (without getting deeper into making custom C types "GC-ready"), and does it really matter for a first implementation? (The tiny memory overhead of a single swift / python object leaking may not affect most users).

I'm looking forward to any feedback you might have