### PR TITLE
update ArgumentParser version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pvieito/LoggerKit.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "0.3.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
update the ArgumentParser dependency version (at v0.3.1 as of Sept 2), and allow up to next major.