### PR TITLE
Implement missing Python calls to make Pandas usage natural

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1202,6 +1202,22 @@ public extension PythonObject {
         return performBinaryOp(PyNumber_Or, lhs: lhs, rhs: rhs)
     }
 
+    static func ^ (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return performBinaryOp(PyNumber_Xor, lhs: lhs, rhs: rhs)
+    }
+
+    static func &= (lhs: inout PythonObject, rhs: PythonObject) {
+        lhs = performBinaryOp(PyNumber_InPlaceAnd, lhs: lhs, rhs: rhs)
+    }
+
+    static func |= (lhs: inout PythonObject, rhs: PythonObject) {
+        lhs = performBinaryOp(PyNumber_InPlaceOr, lhs: lhs, rhs: rhs)
+    }
+
+    static func ^= (lhs: inout PythonObject, rhs: PythonObject) {
+        lhs = performBinaryOp(PyNumber_InPlaceXor, lhs: lhs, rhs: rhs)
+    }
+
     static prefix func ~ (_ operand: Self) -> Self {
         return performUnaryOp(PyNumber_Invert, operand: operand)
     }

--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1193,6 +1193,20 @@ public extension PythonObject {
     }
 }
 
+public extension PythonObject {
+    static func & (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return performBinaryOp(PyNumber_And, lhs: lhs, rhs: rhs)
+    }
+
+    static func | (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return performBinaryOp(PyNumber_Or, lhs: lhs, rhs: rhs)
+    }
+
+    static prefix func ~ (_ operand: Self) -> Self {
+        return performUnaryOp(PyNumber_Invert, operand: operand)
+    }
+}
+
 extension PythonObject : SignedNumeric {
     public init<T : BinaryInteger>(exactly value: T) {
         self.init(Int(value))
@@ -1243,28 +1257,71 @@ extension PythonObject : Equatable, Comparable {
             fatalError("No result or error returned when comparing \(self) to \(other)")
         }
     }
-    
+
     public static func == (lhs: PythonObject, rhs: PythonObject) -> Bool {
         return lhs.compared(to: rhs, byOp: Py_EQ)
     }
-    
+ 
     public static func != (lhs: PythonObject, rhs: PythonObject) -> Bool {
         return lhs.compared(to: rhs, byOp: Py_NE)
     }
-    
+
     public static func < (lhs: PythonObject, rhs: PythonObject) -> Bool {
         return lhs.compared(to: rhs, byOp: Py_LT)
     }
-    
+
     public static func <= (lhs: PythonObject, rhs: PythonObject) -> Bool {
         return lhs.compared(to: rhs, byOp: Py_LE)
     }
-    
+ 
     public static func > (lhs: PythonObject, rhs: PythonObject) -> Bool {
         return lhs.compared(to: rhs, byOp: Py_GT)
     }
     
     public static func >= (lhs: PythonObject, rhs: PythonObject) -> Bool {
+        return lhs.compared(to: rhs, byOp: Py_GE)
+    }
+}
+
+public extension PythonObject {
+    private func compared(to other: PythonObject, byOp: Int32) -> PythonObject {
+        let lhsObject = ownedPyObject
+        let rhsObject = other.ownedPyObject
+        defer {
+            Py_DecRef(lhsObject)
+            Py_DecRef(rhsObject)
+        }
+        assert(PyErr_Occurred() == nil,
+               "Python error occurred somewhere but wasn't handled")
+        guard let result = PyObject_RichCompare(lhsObject, rhsObject, byOp) else {
+            // If a Python exception was thrown, throw a corresponding Swift error.
+            try! throwPythonErrorIfPresent()
+            fatalError("No result or error returned when comparing \(self) to \(other)")
+        }
+        return PythonObject(consuming: result)
+    }
+    
+    static func == (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return lhs.compared(to: rhs, byOp: Py_EQ)
+    }
+    
+    static func != (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return lhs.compared(to: rhs, byOp: Py_NE)
+    }
+    
+    static func < (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return lhs.compared(to: rhs, byOp: Py_LT)
+    }
+    
+    static func <= (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return lhs.compared(to: rhs, byOp: Py_LE)
+    }
+    
+    static func > (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
+        return lhs.compared(to: rhs, byOp: Py_GT)
+    }
+    
+    static func >= (lhs: PythonObject, rhs: PythonObject) -> PythonObject {
         return lhs.compared(to: rhs, byOp: Py_GE)
     }
 }

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -230,5 +230,17 @@ let PyNumber_And: PyBinaryOperation =
 let PyNumber_Or: PyBinaryOperation =
     PythonLibrary.loadSymbol(name: "PyNumber_Or")
 
+let PyNumber_Xor: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_Xor")
+
+let PyNumber_InPlaceAnd: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_InPlaceAnd")
+
+let PyNumber_InPlaceOr: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_InPlaceOr")
+
+let PyNumber_InPlaceXor: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_InPlaceXor")
+
 let PyNumber_Invert: PyUnaryOperation =
     PythonLibrary.loadSymbol(name: "PyNumber_Invert")

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -116,6 +116,10 @@ let PyTuple_SetItem: @convention(c) (
     PyObjectPointer, Int, PyObjectPointer) -> Void =
     PythonLibrary.loadSymbol(name: "PyTuple_SetItem")
 
+let PyObject_RichCompare: @convention(c) (
+    PyObjectPointer, PyObjectPointer, Int32) -> PyObjectPointer? =
+    PythonLibrary.loadSymbol(name: "PyObject_RichCompare")
+
 let PyObject_RichCompareBool: @convention(c) (
     PyObjectPointer, PyObjectPointer, Int32) -> Int32 =
     PythonLibrary.loadSymbol(name: "PyObject_RichCompareBool")
@@ -219,3 +223,12 @@ let PyNumber_InPlaceTrueDivide: PyBinaryOperation =
 
 let PyNumber_Negative: PyUnaryOperation =
     PythonLibrary.loadSymbol(name: "PyNumber_Negative")
+
+let PyNumber_And: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_And")
+
+let PyNumber_Or: PyBinaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_Or")
+
+let PyNumber_Invert: PyUnaryOperation =
+    PythonLibrary.loadSymbol(name: "PyNumber_Invert")


### PR DESCRIPTION
This PR added implementation for PyObject_RichCompare, PyNumber_Invert,
PyNumber_And, PyNumber_Or such that the usual filtering with in pandas
would be more natural. Previously, if you do:

```swift
let pd = Python.import("pandas")
let df = pd.read_csv("a.csv")
print(df[df["column"] == match])
```
Will error, because we only implemented PyObject_RichCompareBool, and it
will return a simple boolean, rather than a complex PyObject for
querying. By implementing PyObject_RichCompare, PyNumber_Invert,
PyNumber_And and PyNumber_Or, I believe we enabled full range of Pandas'
filtering short-hand now:
```swift
let pd = Python.import("pandas")
let df = pd.read_csv("a.csv")
print(df[~((df["column"] == match) | (df["year"] < this_year))])
```

I double checked Swift type inference. If you just do:
```
if onePythonObject == anotherPythonObject {
}
```
The type system will still choose the right `PyObject_RichCompareBool` function.
The confusion only happens if you do:
```
let result = onePythonObject == anotherPythonObject
```
and you can workaround this by providing explicit type. I think this is a small
price to pay to enable a capable library such as Pandas usable within Swift.