### PR TITLE
Update for rename from `MSVCRT` to `CRT`

### DIFF
--- a/.github/workflows/continuous-integration-windows.yml
+++ b/.github/workflows/continuous-integration-windows.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: seanmiddleditch/gha-setup-vsdevenv@master
       - name: Install Swift (Swift Toolchain)
         run: |
-          Install-Binary -Url "https://swift.org/builds/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2020-09-22-a/swift-DEVELOPMENT-SNAPSHOT-2020-09-22-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          Install-Binary -Url "https://swift.org/builds/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2020-11-04-a/swift-DEVELOPMENT-SNAPSHOT-2020-11-04-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
           echo "::set-env name=SDKROOT::C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk"
           echo "::set-env name=DEVELOPER_DIR::C:\Library\Developer"
           echo "::add-path::C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin;C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin"

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/pvieito/LoggerKit.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "0.3.1")),
+        .package(url: "https://github.com/apple/swift-argument-parser", .branch("main")),
     ],
     targets: [
         .target(

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -19,7 +19,7 @@ import Darwin
 #elseif canImport(Glibc)
 import Glibc
 #elseif os(Windows)
-import MSVCRT
+import CRT
 import WinSDK
 #endif
 


### PR DESCRIPTION
The `CRT` module is identical to `MSVCRT` except it does not expose the
`visualc` module.  The `MSVCRT` module has been removed to drop the
explicit dependency on the `visualc` module.