### PR TITLE
Use RTDL_SELF to load embedded symbols

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -27,6 +27,8 @@ import WinSDK
 // The `PythonLibrary` struct that loads Python symbols at runtime.
 //===----------------------------------------------------------------------===//
 
+var RTLD_SELF = UnsafeMutableRawPointer(bitPattern: -3)
+
 public struct PythonLibrary {
     private static let shared = PythonLibrary()
     private static let pythonLegacySymbolName = "PyString_AsString"
@@ -201,6 +203,11 @@ private extension PythonLibrary {
                 }
             }
         }
+        
+        if dlsym(RTLD_SELF, "Py_Initialize") != nil {
+            return RTLD_SELF
+        }
+        
         return nil
     }
     

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -204,9 +204,11 @@ private extension PythonLibrary {
             }
         }
         
+        #if canImport(Darwin)
         if dlsym(RTLD_SELF, "Py_Initialize") != nil {
             return RTLD_SELF
         }
+        #endif
         
         return nil
     }


### PR DESCRIPTION
For platforms like iOS, we have to embed Python to use in our apps.  Examples include:

- https://github.com/beeware/Python-Apple-support
- https://github.com/kivy/kivy-ios

In this case we can load symbols using `dlsym(RTDL_SELF, symbolName)`.
This pull request does it after failing `dlopen()`.