### PR TITLE
Added note on disabling SIP for Xcode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Swift framework to interact with Python.
 
 `PythonKit` requires [**Swift 5**](https://swift.org/download/) or higher and has been tested on macOS, Linux and Windows.
 
+For Xcode projects on macOS it is necessary to set the `Enable Hardened 
+Runtime` build setting to `No`, disabling System Integrity Protection (SIP), 
+in order to allow `libpython` discovery in non-standard locations. 
+
 ## Usage
 
 Some Python code like this:


### PR DESCRIPTION
SIP will silently ignore Python installations outside of standard locations. 
Disabling the hardened runtime is required in this case.

Hi @pvieito — not 100% sure on the exact wording, but some note in the README would be very handy here. 
Let me know if you have ideas for improvements. 
Thanks! 