### PR TITLE
Add UnboundedRange support to PythonObject

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1134,6 +1134,119 @@ where Bound : ConvertibleFromPython {
     }
 }
 
+extension PythonObject {
+    public subscript(key0: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: PythonConvertible, key1: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[key0, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[key0, unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: PythonConvertible) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, key1]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, key1] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: PythonConvertible, key1: UnboundedRange, key2: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[key0, unboundedRange, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[key0, unboundedRange, unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: PythonConvertible, key2: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, key1, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, key1, unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: UnboundedRange, key2: PythonConvertible) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, unboundedRange, key2]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, unboundedRange, key2] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: PythonConvertible, key2: PythonConvertible) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, key1, key2]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, key1, key2] = newValue
+        }
+    }
+    public subscript(key0: PythonConvertible, key1: UnboundedRange, key2: PythonConvertible) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[key0, unboundedRange, key2]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[key0, unboundedRange, key2] = newValue
+        }
+    }
+    public subscript(key0: PythonConvertible, key1: PythonConvertible, key2: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[key0, key1, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[key0, key1, unboundedRange] = newValue
+        }
+    }
+    public subscript(key0: UnboundedRange, key1: UnboundedRange, key2: UnboundedRange) -> PythonObject {
+        get {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            return self[unboundedRange, unboundedRange, unboundedRange]
+        }
+        nonmutating set {
+            let unboundedRange = Python.slice(Python.None, Python.None, Python.None)
+            self[unboundedRange, unboundedRange, unboundedRange] = newValue
+        }
+    }
+}
+
 //===----------------------------------------------------------------------===//
 // Standard operators and conformances
 //===----------------------------------------------------------------------===//

--- a/Tests/PythonKitTests/NumpyConversionTests.swift
+++ b/Tests/PythonKitTests/NumpyConversionTests.swift
@@ -29,4 +29,18 @@ class NumpyConversionTests: XCTestCase {
         XCTAssertNotEqual(numpyArrayStrided.__array_interface__["strides"], Python.None)
         XCTAssertEqual([2, 2], Array<Int32>(numpy: numpyArrayStrided))
     }
+
+    func testNumpyRangeIndexing() {
+      guard let np = NumpyConversionTests.numpyModule else { return }
+
+      let numpyArrayInt32 = np.array([-1, 4, 12, 34, 43, 24, 4, 24], dtype: np.int32)
+      let reshapedTo2x4 = numpyArrayInt32.reshape([2, 4])
+      let copiedFrom2x4WithUnboundedRange = reshapedTo2x4[0, ...]
+      XCTAssertEqual([-1, 4, 12, 34], Array<Int32>(numpy: copiedFrom2x4WithUnboundedRange))
+      let reshapedTo2x2x2 = numpyArrayInt32.reshape([2, 2, 2])
+      let copiedFrom2x2x2WithUnboundedRange = reshapedTo2x2x2[..., 0, ...]
+      XCTAssertEqual(2, copiedFrom2x2x2WithUnboundedRange.shape[0])
+      XCTAssertEqual(2, copiedFrom2x2x2WithUnboundedRange.shape[1])
+      XCTAssertEqual([-1, 4, 43, 24], Array<Int32>(numpy: copiedFrom2x2x2WithUnboundedRange.reshape([4])))
+    }
 }


### PR DESCRIPTION
This PR added UnboundedRange support such that you can make queries like:
```
aNumpyArray[1, ...] = anotherNumpyArray[10, ...]
```
now. Previously, you have to know the bound of the aNumpyArray, or use PartialRange for this purpose.

This PR doesn't look great and only support array up to 3 dimensions. The reason is because extension in Swift only support existential types, and UnboundedRange is an operator (function), hence you cannot extend on it. That means rather than extend UnboundedRange to support PythonObject interface, we have to enumerate UnboundedRange from subscript, which looks ugly.

However, this does make using numpy from within Swift a little bit easier.