### PR TITLE
Define the PythonBytes type.

### DIFF
--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -185,6 +185,20 @@ let PyString_FromStringAndSize: @convention(c) (
         name: "PyUnicode_DecodeUTF8",
         legacyName: "PyString_FromStringAndSize")
 
+let PyBytes_FromStringAndSize: @convention(c) (
+    PyCCharPointer?, Int) -> (PyObjectPointer?) =
+    PythonLibrary.loadSymbol(
+        name: "PyBytes_FromStringAndSize",
+        legacyName: "PyString_FromStringAndSize")
+
+let PyBytes_AsStringAndSize: @convention(c) (
+    PyObjectPointer,
+    UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?,
+    UnsafeMutablePointer<Int>?) -> CInt =
+    PythonLibrary.loadSymbol(
+        name: "PyBytes_AsStringAndSize",
+        legacyName: "PyString_AsStringAndSize")
+
 let _Py_ZeroStruct: PyObjectPointer =
     PythonLibrary.loadSymbol(name: "_Py_ZeroStruct")
 

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -279,4 +279,41 @@ class PythonRuntimeTests: XCTestCase {
             _ = Bool.init(b)
         }
     }
+
+    func testPythonBytes() {
+        let bytes = PythonBytes([UInt8(1), UInt8(2), UInt8(3), UInt8(4)])
+        bytes.withUnsafeBytes {
+            XCTAssertEqual(Array($0), [1, 2, 3, 4])
+        }
+    }
+
+    func testPythonBytesInt8() {
+        let bytes = PythonBytes([Int8(1), Int8(2), Int8(3), Int8(4)])
+        bytes.withUnsafeBytes {
+            XCTAssertEqual(Array($0), [1, 2, 3, 4])
+        }
+    }
+
+    func testPythonBytesNonContiguousSequence() {
+        let bytes = PythonBytes(CollectionOfOne(UInt8(1)))
+        bytes.withUnsafeBytes {
+            XCTAssertEqual(Array($0), [1])
+        }
+    }
+
+    func testPythonBytesNonContiguousSequenceInt8() {
+        let bytes = PythonBytes(CollectionOfOne(Int8(1)))
+        bytes.withUnsafeBytes {
+            XCTAssertEqual(Array($0), [1])
+        }
+    }
+
+    func testBytesConversion() {
+        let bytes = PythonBytes(CollectionOfOne(UInt8(1)))
+        let otherBytes = PythonBytes(bytes.pythonObject)
+        otherBytes?.withUnsafeBytes {
+            XCTAssertEqual(Array($0), [1])
+        }
+        XCTAssertEqual(bytes, otherBytes)
+    }
 }


### PR DESCRIPTION
This type encapsulates the Python byte string object. This requires a
new data type, mostly because there is no natural "bucket of bytes" type
in Swift without adding a Foundation dependency, which this module
currently does not have.

Instead, we can define a little wrapper that makes it as easy as
possible to convert from existing types to the Python bytes object, and
back again.