### PR TITLE
添加python库的路径：/Library/Frameworks/

### DIFF
--- a/PythonKit.podspec
+++ b/PythonKit.podspec
@@ -1,0 +1,28 @@
+# Run `pod lib lint PythonKit.podspec' to ensure this is a valid spec.
+
+Pod::Spec.new do |s|
+  s.name             = 'PythonKit'
+  s.version          = '1.0.1'
+  s.swift_versions   = ['5.3']
+  s.summary          = '...'
+
+  s.description      = <<-DESC
+  description.
+                       DESC
+
+  s.homepage         = 'https://github.com/pvieito/PythonKit.git'
+  s.license          = { :type => 'MIT' }
+  s.author           = { '静静的白色外套' => '296019487@qq.com' }
+  s.source           = { :git => '', :tag => s.version.to_s }
+  s.social_media_url = ''
+
+  s.swift_version = '5.3'
+  s.ios.deployment_target = '13.0'
+  s.tvos.deployment_target = '13.0'
+  s.macos.deployment_target = '11.0'
+  s.watchos.deployment_target = '6.0'
+  
+  s.source_files = 'PythonKit/**/*.swift'
+  
+  
+end

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -270,7 +270,8 @@ extension PythonLibrary {
 // Methods of `PythonLibrary` used for logging messages.
 extension PythonLibrary {
     private static func log(_ message: String) {
-        guard Environment.loaderLogging.value != nil else { return }
+        
+//        guard Environment.loaderLogging.value != nil else { return }
         fputs(message + "\n", stderr)
     }
 }

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -81,7 +81,7 @@ extension PythonLibrary {
     #if canImport(Darwin)
     private static var libraryNames = ["Python.framework/Versions/:/Python"]
     private static var libraryPathExtensions = [""]
-    private static var librarySearchPaths = ["", "/usr/local/Frameworks/"]
+    private static var librarySearchPaths = ["", "/usr/local/Frameworks/","/Library/Frameworks/"]
     private static var libraryVersionSeparator = "."
     #elseif os(Linux)
     private static var libraryNames = ["libpython:", "libpython:m"]


### PR DESCRIPTION
M1 mac pro 安装python在/Library/Frameworks/下导致找不到python库，新增了/Library/Frameworks/

另外有两个问题，希望能够得到解答
#  无法找到python库
在使用的过程中，一直不明白
PythonLibrary.useVersion
PythonLibrary.useLibrary
这两个方法怎么设置，试了一下几个：
```
       PythonLibrary.useVersion(3, 8)
       PythonLibrary.useVersion(3)
       PythonLibrary.useLibrary(at: "/usr/local/bin/python3.8")
```
都不能工作，提示：
> Python library not found. Set the PYTHON_LIBRARY environment variable with the path to a Python library

PYTHON_LIBRARY 不知道怎么设置，太难了！！！
#  无法使用mac自带python3
这次Mac 更新的时候添加了python3的库，直接调用
```
 PythonLibrary.useLibrary(at: "/usr/bin/python3")
 let py_sys = Python.import("sys")
```
提示：sys 错误


