### PR TITLE
macOS default Python support

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -81,7 +81,7 @@ extension PythonLibrary {
     #if canImport(Darwin)
     private static var libraryNames = ["Python.framework/Versions/:/Python"]
     private static var libraryPathExtensions = [""]
-    private static var librarySearchPaths = ["", "/usr/local/Frameworks/"]
+    private static var librarySearchPaths = ["", "/usr/local/Frameworks/", "/Library/Frameworks/"]
     private static var libraryVersionSeparator = "."
     #elseif os(Linux)
     private static var libraryNames = ["libpython:", "libpython:m"]


### PR DESCRIPTION
This adds support for the default macOS python installation (not homebrew) by adding `/Library/Frameworks/` to library search paths.

For more details, see: https://forums.swift.org/t/how-to-implement-python-into-xcode-using-pythonkit-3rd-party-software-or-any-others-please-suggest/32319/12