### PR TITLE
Add function to check python availability

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -126,6 +126,11 @@ extension PythonLibrary {
         let pythonLibraryHandle = pythonLibraryHandle ?? self.defaultLibraryHandle
         return self.loadSymbol(pythonLibraryHandle, self.pythonInitializeSymbolName) != nil
     }
+    
+    public static func isPythonAvailable() -> Bool {
+        let pythonLibraryHandle = Self.loadPythonLibrary()
+        return Self.isPythonLibraryLoaded(at: pythonLibraryHandle)
+    }
 
     private static func loadPythonLibrary() -> UnsafeMutableRawPointer? {
         let pythonLibraryHandle: UnsafeMutableRawPointer?


### PR DESCRIPTION
Hi,

I have tried to find a way to check if a certain version of Python is available or not. The following snippet of code for example would give me a "fatal error" if Python 3.8 is not installed.
```swift
PythonLibrary.useVersion(3, 8)
let sys = Python.import("sys")
```
But in my application, the python module would be an optional add-on, so it is not at all fatal when it is not available. In this case, I would inform the user to install python 3.8 for additional functionality, but the app would continue to work anyways.

For this reason, I suggest adding a function to check if the selected version of Python is available.
