### PR TITLE
Allow defining Swift functions to be called from Python with revisions

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1584,11 +1584,10 @@ extension PythonFunction : PythonConvertible {
     }
 }
 
-// The pointers here technically constitute a leak, but no more than
-// a static string or a static struct definition at top level.
 fileprivate extension PythonFunction {
     static let sharedFunctionName: UnsafePointer<Int8> = {
         let name: StaticString = "pythonkit_swift_function"
+        // `utf8Start` is a property of StaticString, thus, it has a stable pointer.
         return UnsafeRawPointer(name.utf8Start).assumingMemoryBound(to: Int8.self)
     }()
 
@@ -1661,4 +1660,3 @@ struct PyMethodDef {
     /// The __doc__ attribute, or NULL
     public var ml_doc: UnsafePointer<Int8>?
 }
->>>>>>> Squashed commit of the following:

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -20,6 +20,7 @@
 
 @usableFromInline
 typealias PyObjectPointer = UnsafeMutableRawPointer
+typealias PyMethodDefPointer = UnsafeMutableRawPointer
 typealias PyCCharPointer = UnsafePointer<Int8>
 typealias PyBinaryOperation =
     @convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?
@@ -55,6 +56,15 @@ let PyEval_GetBuiltins: @convention(c) () -> PyObjectPointer =
 
 let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
     PythonLibrary.loadSymbol(name: "PyRun_SimpleString")
+
+let PyCFunction_New: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer) -> PyObjectPointer =
+    PythonLibrary.loadSymbol(name: "PyCFunction_New")
+
+let PyObject_GC_UnTrack: @convention(c) (PyObjectPointer) -> Void =
+    PythonLibrary.loadSymbol(name: "PyObject_GC_UnTrack")
+
+let PyErr_SetString: @convention(c) (PyObjectPointer, UnsafePointer<CChar>?) -> Void =
+    PythonLibrary.loadSymbol(name: "PyErr_SetString")
 
 let PyErr_Occurred: @convention(c) () -> PyObjectPointer? =
     PythonLibrary.loadSymbol(name: "PyErr_Occurred")

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -60,9 +60,6 @@ let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
 let PyCFunction_New: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer) -> PyObjectPointer =
     PythonLibrary.loadSymbol(name: "PyCFunction_New")
 
-let PyObject_GC_UnTrack: @convention(c) (PyObjectPointer) -> Void =
-    PythonLibrary.loadSymbol(name: "PyObject_GC_UnTrack")
-
 let PyErr_SetString: @convention(c) (PyObjectPointer, UnsafePointer<CChar>?) -> Void =
     PythonLibrary.loadSymbol(name: "PyErr_SetString")
 

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -25,7 +25,9 @@ typealias PyCCharPointer = UnsafePointer<Int8>
 typealias PyBinaryOperation =
     @convention(c) (PyObjectPointer?, PyObjectPointer?) -> PyObjectPointer?
 typealias PyUnaryOperation =
-    @convention(c) (PyObjectPointer?) -> PyObjectPointer?    
+    @convention(c) (PyObjectPointer?) -> PyObjectPointer?
+typealias PyCapsuleDestructor =
+    @convention(c) (PyObjectPointer?) -> Void
 
 let Py_LT: Int32 = 0
 let Py_LE: Int32 = 1
@@ -59,6 +61,12 @@ let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
 
 let PyCFunction_New: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer) -> PyObjectPointer =
     PythonLibrary.loadSymbol(name: "PyCFunction_New")
+
+let PyCapsule_New: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>?, PyCapsuleDestructor) -> PyObjectPointer =
+    PythonLibrary.loadSymbol(name: "PyCapsule_New")
+
+let PyCapsule_GetPointer: @convention(c) (PyObjectPointer?, UnsafePointer<CChar>?) -> UnsafeMutableRawPointer =
+    PythonLibrary.loadSymbol(name: "PyCapsule_GetPointer")
 
 let PyErr_SetString: @convention(c) (PyObjectPointer, UnsafePointer<CChar>?) -> Void =
     PythonLibrary.loadSymbol(name: "PyErr_SetString")


### PR DESCRIPTION
This PR merged what's left from https://github.com/pvieito/PythonKit/pull/25 and fixed 3 issues:

 1. the second parameter to PyFunction_New expects a Python object pointer, whereas we passed a raw function pointer directly: https://docs.python.org/3/c-api/function.html#c.PyFunction_New
 2. To get a stable static string pointer, we should assume the string literal is StaticString and use utf8Start instead: liuliu@d7d8d43#diff-271e10211ef0b04c649337c9bb6490e494806134bb410abd4efff3109b23e5b4R1593
 3. Memory leak when creating PythonFunction is fixed by wrapped in a PyCapsule structure: https://docs.python.org/3/c-api/capsule.html

@pvieito @ephemer