### PR TITLE
Revert add support for non-returning functions

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1550,25 +1550,11 @@ public struct PythonFunction {
             return try fn(argumentsAsTuple[0])
         }
     }
-    
-    public init(_ fn: @escaping (PythonObject) throws -> Void) {
-        function = PyFunction { argumentsAsTuple in
-            try fn(argumentsAsTuple[0])
-            return Python.None
-        }
-    }
 
     /// For cases where the Swift function should accept more (or less) than one parameter, accept an ordered array of all arguments instead
     public init(_ fn: @escaping ([PythonObject]) throws -> PythonConvertible) {
         function = PyFunction { argumentsAsTuple in
             return try fn(argumentsAsTuple.map { $0 })
-        }
-    }
-    
-    public init(_ fn: @escaping ([PythonObject]) throws -> Void) {
-        function = PyFunction { argumentsAsTuple in
-            try fn(argumentsAsTuple.map { $0 })
-            return Python.None
         }
     }
 }


### PR DESCRIPTION
My [previous PR](https://github.com/pvieito/PythonKit/pull/42) stops Swift from type-inferring the function signature. Previously, this would compile successfully:

```swift
let myFunction = PythonFunction { (params: Array) in
    print(params.debugDescription)
    return Python.None
}
```

Now, there's a compile-time error because `init(_:)` is ambiguous.