### PR TITLE
Fix crash

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1588,9 +1588,10 @@ extension PythonFunction : PythonConvertible {
             Unmanaged<PyFunction>.fromOpaque(funcPointer).release()
         })
 
-        let pyFuncPointer = PyCFunction_New(
+        let pyFuncPointer = PyCFunction_NewEx(
             PythonFunction.sharedMethodDefinition,
-            capsulePointer
+            capsulePointer,
+            nil
         )
 
         return PythonObject(consuming: pyFuncPointer)

--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -59,8 +59,8 @@ let PyEval_GetBuiltins: @convention(c) () -> PyObjectPointer =
 let PyRun_SimpleString: @convention(c) (PyCCharPointer) -> Void =
     PythonLibrary.loadSymbol(name: "PyRun_SimpleString")
 
-let PyCFunction_New: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer) -> PyObjectPointer =
-    PythonLibrary.loadSymbol(name: "PyCFunction_New")
+let PyCFunction_NewEx: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPointer, UnsafeMutableRawPointer?) -> PyObjectPointer =
+    PythonLibrary.loadSymbol(name: "PyCFunction_NewEx")
 
 let PyCapsule_New: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>?, PyCapsuleDestructor) -> PyObjectPointer =
     PythonLibrary.loadSymbol(name: "PyCapsule_New")

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -328,6 +328,12 @@ class PythonRuntimeTests: XCTestCase {
     }
     
     func testPythonFunction() {
+        let versionMajor = Python.versionInfo.major
+        let versionMinor = Python.versionInfo.minor
+        guard (versionMajor == 3 && versionMinor >= 1) || versionMajor > 3 else {
+            return
+        }
+        
         let pythonAdd = PythonFunction { (params: [PythonObject]) in
             let lhs = params[0]
             let rhs = params[1]

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -326,4 +326,16 @@ class PythonRuntimeTests: XCTestCase {
         }
         XCTAssertEqual(bytes, otherBytes)
     }
+    
+    func testPythonFunction() {
+        let pythonAdd = PythonFunction { (params: [PythonObject]) in
+            let lhs = params[0]
+            let rhs = params[1]
+            return lhs + rhs
+        }.pythonObject
+        
+        let pythonSum = pythonAdd(2, 3)
+        XCTAssertNotNil(Double(pythonSum))
+        XCTAssertEqual(pythonSum, 5)
+    }
 }


### PR DESCRIPTION
When I set Python to use 3.9 instead of 3.10, it crashes upon materializing a `PythonFunction`'s object. The culprit is the `PyCFunction_New` function, as documented in https://github.com/clj-python/libpython-clj/issues/105. We can work around this by calling `PyCFunction_NewEx` and passing `nil` into the last parameter. This workaround should stay permanent because people might use Python 3.9 in the future.