### PR TITLE
Fix compiler failure

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1711,6 +1711,7 @@ public struct PythonClass {
         self.init(name, superclasses: superclasses, members: members.dictionary)
     }
     
+    @_disfavoredOverload
     public init(_ name: String, superclasses: [PythonObject] = [], members: [String: PythonObject] = [:]) {
         var trueSuperclasses = superclasses
         if !trueSuperclasses.contains(Python.object) {

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -84,6 +84,14 @@ class PythonFunctionTests: XCTestCase {
         XCTAssertEqual(printOutput, "Class Dynamically Created!")
     }
     
+    // There is a build error where passing a simple `PythonClass.Members` 
+    // literal makes the literal's type ambiguous. It is confused with
+    // `[String: PythonObject]`. To fix this error, we add a
+    // `@_disfavoredOverload` attribute to the more specific initializer.
+    func testPythonClassInitializer() {
+        
+    }
+    
     func testPythonClassInheritance() {
         guard canUsePythonFunction else {
             return

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -89,7 +89,20 @@ class PythonFunctionTests: XCTestCase {
     // `[String: PythonObject]`. To fix this error, we add a
     // `@_disfavoredOverload` attribute to the more specific initializer.
     func testPythonClassInitializer() {
+        guard canUsePythonFunction else {
+            return
+        }
         
+        let MyClass = PythonClass(
+            "MyClass",
+            superclasses: [Python.object],
+            members: [
+              "memberName": "memberValue",
+            ]
+        ).pythonObject
+        
+        let memberValue = MyClass().memberName
+        XCTAssertEqual(String(memberValue), "memberValue")
     }
     
     func testPythonClassInheritance() {

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -127,7 +127,7 @@ class PythonFunctionTests: XCTestCase {
                     helloOutput = String(message)
                     
                     // Conventional `super` syntax causes problems; use this instead.
-                    Python.Exception.__init__(self, message)
+                    Python.Exception.__init__(`self`, message)
                     return Python.None
                 },
                 
@@ -151,7 +151,7 @@ class PythonFunctionTests: XCTestCase {
                     `self`.int_param = params[2]
                     
                     // Conventional `super` syntax causes problems; use this instead.
-                    HelloException.__init__(self, message)
+                    HelloException.__init__(`self`, message)
                     return Python.None
                 },
                 


### PR DESCRIPTION
I came across a compiler failure while working on Swift-Colab. There is a build error where passing a simple `PythonClass.Members` literal makes the literal's type ambiguous. It is confused with `[String: PythonObject]`. To fix this error, we add a `@_disfavoredOverload` attribute to the more specific initializer. The reproducer is located in the new test case.

To reproduce the build failure, delete the `@_disfavoredOverload` attribute that was added and run the package tests.