### PR TITLE
Count computed property

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1400,6 +1400,11 @@ extension PythonObject : Sequence {
     }
 }
 
+extension PythonObject {
+    public var count: Int { 
+        Int(Python.len(self))!
+    }
+}
 
 //===----------------------------------------------------------------------===//
 // `ExpressibleByLiteral` conformances


### PR DESCRIPTION
Currently the `count` property is derived from the `Sequence` default implementation which is O(n). I suggest implementing the `count` of a `PythonObject` as the value returned by `Python.len()` :
* It will be faster to access the count of an object
* It will fail is the object has no length

This change could speed-up code that relies on indices and use `count` :

```swift
import PythonKit

let array = [Int](repeating: 0, count: 1_000_000_000).pythonObject
let half = array.count / 2  // Currently a O(n) operation
let elements = array[..<half]
```

Maybe other performance critical `Sequence` conformances could be supplied as well, such as `underestimatedCount`, or `Collection`'s `distance()`.