### PR TITLE
Add further support for count computed property

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -394,6 +394,10 @@ public struct ThrowingPythonObject {
         }
         return (elt0, elt1, elt2, elt3)
     }
+    
+    public var count: Int? {
+        base.checking.count
+    }
 }
 
 
@@ -506,6 +510,10 @@ public struct CheckingPythonObject {
                 return nil
         }
         return (elt0, elt1, elt2, elt3)
+    }
+    
+    public var count: Int? {
+        Int(Python.len(base))
     }
 }
 
@@ -1402,7 +1410,7 @@ extension PythonObject : Sequence {
 
 extension PythonObject {
     public var count: Int { 
-        Int(Python.len(self))!
+        checking.count!
     }
 }
 

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -20,7 +20,7 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(1.5, polymorphicList[3])
         XCTAssertEqual(1.5, polymorphicList[-1])
         
-        XCTAssertEqual(4, polymorphicList.count)
+        XCTAssertEqual(4, polymorphicList.count as Int)
         XCTAssertEqual(4, polymorphicList.checking.count!)
         XCTAssertEqual(4, polymorphicList.throwing.count!)
         
@@ -35,7 +35,7 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(1, dict["a"])
         XCTAssertEqual(0.5, dict[1])
       
-        XCTAssertEqual(2, dict.count)
+        XCTAssertEqual(2, dict.count as Int)
         XCTAssertEqual(2, dict.checking.count!)
         XCTAssertEqual(2, dict.throwing.count!)
         

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -20,6 +20,10 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(1.5, polymorphicList[3])
         XCTAssertEqual(1.5, polymorphicList[-1])
         
+        XCTAssertEqual(4, polymorphicList.count)
+        XCTAssertEqual(4, polymorphicList.checking.count!)
+        XCTAssertEqual(4, polymorphicList.throwing.count!)
+        
         polymorphicList[2] = 2
         XCTAssertEqual(2, polymorphicList[2])
     }
@@ -30,6 +34,10 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(2, Python.len(dict))
         XCTAssertEqual(1, dict["a"])
         XCTAssertEqual(0.5, dict[1])
+      
+        XCTAssertEqual(2, polymorphicList.count)
+        XCTAssertEqual(2, polymorphicList.checking.count!)
+        XCTAssertEqual(2, polymorphicList.throwing.count!)
         
         dict["b"] = "c"
         XCTAssertEqual("c", dict["b"])

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -35,9 +35,9 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(1, dict["a"])
         XCTAssertEqual(0.5, dict[1])
       
-        XCTAssertEqual(2, polymorphicList.count)
-        XCTAssertEqual(2, polymorphicList.checking.count!)
-        XCTAssertEqual(2, polymorphicList.throwing.count!)
+        XCTAssertEqual(2, dict.count)
+        XCTAssertEqual(2, dict.checking.count!)
+        XCTAssertEqual(2, dict.throwing.count!)
         
         dict["b"] = "c"
         XCTAssertEqual("c", dict["b"])


### PR DESCRIPTION
This PR builds on #49. It adds the new `count` computed property to `CheckingPythonObject` and `ThrowingPythonObject`, so that their behavior does not differ from `PythonObject`. Also, support for the new property is now validated in tests.