### PR TITLE
Add support for `**kwargs`

### DIFF
--- a/PythonKit/PythonLibrary+Symbols.swift
+++ b/PythonKit/PythonLibrary+Symbols.swift
@@ -63,9 +63,13 @@ let PyCFunction_NewEx: @convention(c) (PyMethodDefPointer, UnsafeMutableRawPoint
 let PyInstanceMethod_New: @convention(c) (PyObjectPointer) -> PyObjectPointer =
     PythonLibrary.loadSymbol(name: "PyInstanceMethod_New")
 
+/// The last argument would ideally be of type `@convention(c) (PyObjectPointer?) -> Void`.
+/// Due to SR-15871 and the source-breaking nature of potential workarounds, the
+/// static typing was removed. The caller must now manually cast a closure to
+/// `OpaquePointer` before passing it into `PyCapsule_New`.
 let PyCapsule_New: @convention(c) (
     UnsafeMutableRawPointer, UnsafePointer<CChar>?,
-    @convention(c) @escaping (PyObjectPointer?) -> Void) -> PyObjectPointer =
+    OpaquePointer) -> PyObjectPointer =
     PythonLibrary.loadSymbol(name: "PyCapsule_New")
 
 let PyCapsule_GetPointer: @convention(c) (PyObjectPointer?, UnsafePointer<CChar>?) -> UnsafeMutableRawPointer =

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -13,15 +13,39 @@ class PythonFunctionTests: XCTestCase {
             return
         }
         
-        let pythonAdd = PythonFunction { (params: [PythonObject]) in
-            let lhs = params[0]
-            let rhs = params[1]
+        let pythonAdd = PythonFunction { (args: [PythonObject]) in
+            let lhs = args[0]
+            let rhs = args[1]
             return lhs + rhs
         }.pythonObject
-        
+
         let pythonSum = pythonAdd(2, 3)
         XCTAssertNotNil(Double(pythonSum))
         XCTAssertEqual(pythonSum, 5)
+        
+        // Test function with keyword arguments
+        
+        // Since there is no alternative function signature, `args` and `kwargs`
+        // can be used without manually stating their type. This differs from
+        // the behavior when there are no keywords.
+        let pythonSelect = PythonFunction { args, kwargs in
+            // NOTE: This may fail on Python versions before 3.6 because they do
+            // not preserve order of keyword arguments
+            XCTAssertEqual(args[0], true)
+            XCTAssertEqual(kwargs[0].key, "y")
+            XCTAssertEqual(kwargs[0].value, 2)
+            XCTAssertEqual(kwargs[1].key, "x")
+            XCTAssertEqual(kwargs[1].value, 3)
+            
+            let conditional = Bool(args[0])!
+            let xIndex = kwargs.firstIndex(where: { $0.key == "x" })!
+            let yIndex = kwargs.firstIndex(where: { $0.key == "y" })!
+            
+            return kwargs[conditional ? xIndex : yIndex].value
+        }.pythonObject
+        
+        let pythonSelectOutput = pythonSelect(true, y: 2, x: 3)
+        XCTAssertEqual(pythonSelectOutput, 3)
     }
     
     // From https://www.geeksforgeeks.org/create-classes-dynamically-in-python
@@ -30,9 +54,9 @@ class PythonFunctionTests: XCTestCase {
             return
         }
         
-        let constructor = PythonInstanceMethod { (params: [PythonObject]) in
-            let `self` = params[0]
-            let arg = params[1]
+        let constructor = PythonInstanceMethod { (args: [PythonObject]) in
+            let `self` = args[0]
+            let arg = args[1]
             `self`.constructor_arg = arg
             return Python.None
         }
@@ -40,23 +64,23 @@ class PythonFunctionTests: XCTestCase {
         // Instead of calling `print`, use this to test what would be output.
         var printOutput: String?
 
-        let displayMethod = PythonInstanceMethod { (params: [PythonObject]) in
+        let displayMethod = PythonInstanceMethod { (args: [PythonObject]) in
             // let `self` = params[0]
-            let arg = params[1]
+            let arg = args[1]
             printOutput = String(arg)
             return Python.None
         }
 
-        let classMethodOriginal = PythonInstanceMethod { (params: [PythonObject]) in
+        let classMethodOriginal = PythonInstanceMethod { (args: [PythonObject]) in
             // let cls = params[0]
-            let arg = params[1]
+            let arg = args[1]
             printOutput = String(arg)
             return Python.None
         }
 
-        // Did not explicitly convert `constructor` or `displayMethod` to PythonObject.
-        // This is intentional, as the `PythonClass` initializer should take any
-        // `PythonConvertible` and not just `PythonObject`.
+        // Did not explicitly convert `constructor` or `displayMethod` to
+        // PythonObject. This is intentional, as the `PythonClass` initializer
+        // should take any `PythonConvertible` and not just `PythonObject`.
         let classMethod = Python.classmethod(classMethodOriginal.pythonObject)
 
         let Geeks = PythonClass("Geeks", members: [
@@ -84,9 +108,9 @@ class PythonFunctionTests: XCTestCase {
         XCTAssertEqual(printOutput, "Class Dynamically Created!")
     }
     
-    // There is a build error where passing a simple `PythonClass.Members` 
-    // literal makes the literal's type ambiguous. It is confused with
-    // `[String: PythonObject]`. To fix this error, we add a
+    // Previously, there was a build error where passing a simple
+    // `PythonClass.Members` literal made the literal's type ambiguous. It was
+    // confused with `[String: PythonObject]`. The solution was adding a
     // `@_disfavoredOverload` attribute to the more specific initializer.
     func testPythonClassInitializer() {
         guard canUsePythonFunction else {
@@ -121,12 +145,12 @@ class PythonFunctionTests: XCTestCase {
             members: [
                 "str_prefix": "HelloException-prefix ",
                 
-                "__init__": PythonInstanceMethod { (params: [PythonObject]) in
-                    let `self` = params[0]
-                    let message = "hello \(params[1])"
+                "__init__": PythonInstanceMethod { (args: [PythonObject]) in
+                    let `self` = args[0]
+                    let message = "hello \(args[1])"
                     helloOutput = String(message)
                     
-                    // Conventional `super` syntax causes problems; use this instead.
+                    // Conventional `super` syntax does not work; use this instead.
                     Python.Exception.__init__(`self`, message)
                     return Python.None
                 },
@@ -143,14 +167,14 @@ class PythonFunctionTests: XCTestCase {
             members: [
                 "str_prefix": "HelloWorldException-prefix ",
                 
-                "__init__": PythonInstanceMethod { (params: [PythonObject]) in
-                    let `self` = params[0]
-                    let message = "world \(params[1])"
+                "__init__": PythonInstanceMethod { (args: [PythonObject]) in
+                    let `self` = args[0]
+                    let message = "world \(args[1])"
                     helloWorldOutput = String(message)
                     
-                    `self`.int_param = params[2]
+                    `self`.int_param = args[2]
                     
-                    // Conventional `super` syntax causes problems; use this instead.
+                    // Conventional `super` syntax does not work; use this instead.
                     HelloException.__init__(`self`, message)
                     return Python.None
                 },
@@ -196,5 +220,120 @@ class PythonFunctionTests: XCTestCase {
         } catch {
             XCTFail("Got error that was not a Python exception: \(error.localizedDescription)")
         }
+    }
+    
+    // Tests the ability to dynamically construct an argument list with keywords
+    // and instantiate a `PythonInstanceMethod` with keywords.
+    func testPythonClassInheritanceWithKeywords() {
+        guard canUsePythonFunction else {
+            return
+        }
+        
+        func getValue(key: String, kwargs: [(String, PythonObject)]) -> PythonObject {
+            let index = kwargs.firstIndex(where: { $0.0 == key })!
+            return kwargs[index].1
+        }
+        
+        // Base class has the following arguments:
+        // __init__():
+        // - 1 unnamed argument
+        // - param1
+        // - param2
+        //
+        // test_method():
+        // - param1
+        // - param2
+        
+        let BaseClass = PythonClass(
+            "BaseClass",
+            superclasses: [],
+            members: [
+                "__init__": PythonInstanceMethod { args, kwargs in
+                    let `self` = args[0]
+                    `self`.arg1 = args[1]
+                    `self`.param1 = getValue(key: "param1", kwargs: kwargs)
+                    `self`.param2 = getValue(key: "param2", kwargs: kwargs)
+                    return Python.None
+                },
+                
+                "test_method": PythonInstanceMethod { args, kwargs in
+                    let `self` = args[0]
+                    `self`.param1 += getValue(key: "param1", kwargs: kwargs)
+                    `self`.param2 += getValue(key: "param2", kwargs: kwargs)
+                    return Python.None
+                }
+            ]
+        ).pythonObject
+        
+        // Derived class accepts the following arguments:
+        // __init__():
+        // - param2
+        // - param3
+        //
+        // test_method():
+        // - param1
+        // - param2
+        // - param3
+        
+        let DerivedClass = PythonClass(
+            "DerivedClass",
+            superclasses: [],
+            members: [
+                "__init__": PythonInstanceMethod { args, kwargs in
+                    let `self` = args[0]
+                    `self`.param3 = getValue(key: "param3", kwargs: kwargs)
+                    
+                    // Lists the arguments in an order different than they are
+                    // specified (self, param2, param3, param1, arg1). The
+                    // correct order is (self, arg1, param1, param2, param3).
+                    let newKeywordArguments = args.map {
+                        ("", $0)
+                    } + kwargs + [
+                        ("param1", 1),
+                        ("", 0)
+                    ]
+                    
+                    BaseClass.__init__.dynamicallyCall(
+                        withKeywordArguments: newKeywordArguments)
+                    return Python.None
+                },
+                
+                "test_method": PythonInstanceMethod { args, kwargs in
+                    let `self` = args[0]
+                    `self`.param3 += getValue(key: "param3", kwargs: kwargs)
+                    
+                    BaseClass.test_method.dynamicallyCall(
+                        withKeywordArguments: args.map { ("", $0) } + kwargs)
+                    return Python.None
+                }
+            ]
+        ).pythonObject
+        
+        let derivedInstance = DerivedClass(param2: 2, param3: 3)
+        XCTAssertEqual(derivedInstance.arg1, 0)
+        XCTAssertEqual(derivedInstance.param1, 1)
+        XCTAssertEqual(derivedInstance.param2, 2)
+        XCTAssertEqual(derivedInstance.checking.param3, 3)
+        
+        derivedInstance.test_method(param1: 1, param2: 2, param3: 3)
+        XCTAssertEqual(derivedInstance.arg1, 0)
+        XCTAssertEqual(derivedInstance.param1, 2)
+        XCTAssertEqual(derivedInstance.param2, 4)
+        XCTAssertEqual(derivedInstance.checking.param3, 6)
+        
+        // Validate that subclassing and instantiating the derived class does
+        // not affect behavior of the parent class.
+        
+        let baseInstance = BaseClass(0, param1: 10, param2: 20)
+        XCTAssertEqual(baseInstance.arg1, 0)
+        XCTAssertEqual(baseInstance.param1, 10)
+        XCTAssertEqual(baseInstance.param2, 20)
+        XCTAssertEqual(baseInstance.checking.param3, nil)
+        
+        baseInstance.test_method(param1: 10, param2: 20)
+        XCTAssertEqual(baseInstance.arg1, 0)
+        XCTAssertEqual(baseInstance.param1, 20)
+        XCTAssertEqual(baseInstance.param2, 40)
+        XCTAssertEqual(baseInstance.checking.param3, nil)
     }
 }


### PR DESCRIPTION
This is yet another spawn of Swift-Colab. I modified the internal representation of `PyFunction` to store an opaque function pointer that casts to two different types. There is also a new method on `PythonObject` and `ThrowingPythonObject`, but that does not interfere with the existing `dynamicCallable` functionality. Furthermore, I future-proofed PythonKit against any solutions to [SR-15871](https://bugs.swift.org/browse/SR-15871).

I did make some minor modifications to code style. One was ensuring the first line in a function was indented once. Previously, it could be indented twice if there was a `where` clause. Also, I changed `params` to `args` in closures for declaration of `PythonFunction`.