### PR TITLE
Use @_disfavoredOverload to enable more ergonomic syntax for PythonFunction

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -1558,6 +1558,7 @@ public struct PythonFunction {
     /// Called directly by the Python C API
     private var function: PyFunction
 
+    @_disfavoredOverload
     public init(_ fn: @escaping (PythonObject) throws -> PythonConvertible) {
         function = PyFunction { argumentsAsTuple in
             return try fn(argumentsAsTuple[0])
@@ -1681,6 +1682,7 @@ struct PyMethodDef {
 public struct PythonInstanceMethod {
     private var function: PythonFunction
     
+    @_disfavoredOverload
     public init(_ fn: @escaping (PythonObject) throws -> PythonConvertible) {
         function = PythonFunction(fn)
     }

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -13,9 +13,9 @@ class PythonFunctionTests: XCTestCase {
             return
         }
         
-        let pythonAdd = PythonFunction { (params: [PythonObject]) in
-            let lhs = params[0]
-            let rhs = params[1]
+        let pythonAdd = PythonFunction { args in
+            let lhs = args[0]
+            let rhs = args[1]
             return lhs + rhs
         }.pythonObject
         
@@ -30,27 +30,25 @@ class PythonFunctionTests: XCTestCase {
             return
         }
         
-        let constructor = PythonInstanceMethod { (params: [PythonObject]) in
-            let `self` = params[0]
-            let arg = params[1]
-            `self`.constructor_arg = arg
+        let constructor = PythonInstanceMethod { args in
+            let `self` = args[0]
+            `self`.constructor_arg = args[1]
             return Python.None
         }
 
         // Instead of calling `print`, use this to test what would be output.
         var printOutput: String?
 
-        let displayMethod = PythonInstanceMethod { (params: [PythonObject]) in
-            // let `self` = params[0]
-            let arg = params[1]
-            printOutput = String(arg)
+        // Example of function using an alternative syntax for `args`.
+        let displayMethod = PythonInstanceMethod { (args: [PythonObject]) in
+            // let `self` = args[0]
+            printOutput = String(args[1])
             return Python.None
         }
 
-        let classMethodOriginal = PythonInstanceMethod { (params: [PythonObject]) in
-            // let cls = params[0]
-            let arg = params[1]
-            printOutput = String(arg)
+        let classMethodOriginal = PythonInstanceMethod { args in
+            // let cls = args[0]
+            printOutput = String(args[1])
             return Python.None
         }
 
@@ -121,9 +119,9 @@ class PythonFunctionTests: XCTestCase {
             members: [
                 "str_prefix": "HelloException-prefix ",
                 
-                "__init__": PythonInstanceMethod { (params: [PythonObject]) in
-                    let `self` = params[0]
-                    let message = "hello \(params[1])"
+                "__init__": PythonInstanceMethod { args in
+                    let `self` = args[0]
+                    let message = "hello \(args[1])"
                     helloOutput = String(message)
                     
                     // Conventional `super` syntax causes problems; use this instead.
@@ -131,6 +129,7 @@ class PythonFunctionTests: XCTestCase {
                     return Python.None
                 },
                 
+                // Example of function using the `self` convention instead of `args`.
                 "__str__": PythonInstanceMethod { (`self`: PythonObject) in
                     return `self`.str_prefix + Python.repr(`self`)
                 }
@@ -143,18 +142,19 @@ class PythonFunctionTests: XCTestCase {
             members: [
                 "str_prefix": "HelloWorldException-prefix ",
                 
-                "__init__": PythonInstanceMethod { (params: [PythonObject]) in
-                    let `self` = params[0]
-                    let message = "world \(params[1])"
+                "__init__": PythonInstanceMethod { args in
+                    let `self` = args[0]
+                    let message = "world \(args[1])"
                     helloWorldOutput = String(message)
                     
-                    `self`.int_param = params[2]
+                    `self`.int_param = args[2]
                     
                     // Conventional `super` syntax causes problems; use this instead.
                     HelloException.__init__(`self`, message)
                     return Python.None
                 },
                 
+                // Example of function using the `self` convention instead of `args`.
                 "custom_method": PythonInstanceMethod { (`self`: PythonObject) in
                     return `self`.int_param
                 }
@@ -178,7 +178,9 @@ class PythonFunctionTests: XCTestCase {
         
         // Test that subclasses behave like Python exceptions
 
-        let testFunction = PythonFunction { (_: [PythonObject]) in
+        // Example of function with no named parameters, which can be stated
+        // ergonomically using an underscore. The ignored input is a [PythonObject].
+        let testFunction = PythonFunction { _ in
             throw HelloWorldException("EXAMPLE ERROR MESSAGE", 2)
         }.pythonObject
         


### PR DESCRIPTION
This pull request makes the syntax for existing function conventions mirror that introduced in #53. For example, functions with keyword arguments can be called like so:

```swift
PythonInstanceMethod { args, kwargs in ... }
```

But functions without keyword arguments must use less ergonomic syntax:

```swift
PythonInstanceMethod { (`self`: PythonObject) in ... }
PythonInstanceMethod ( (args: [PythonObject]) in ... }
```

This pull request uses `@_disfavoredOverload` to enable a new behavior: concise use of the `args: [PythonObject]` calling convention. It will have merge conflicts with #53 in its current incarnation, due to employment of this new syntax in the test suite.

```swift
PythonInstanceMethod { args in ... }
```

There can only be one calling convention that benefits from this behavior: either `PythonObject` (single argument) or `[PythonObject]` (multiple arguments). I prefer multiple arguments because it is more general-purpose and more closely mirrors `args, kwargs`. The single-argument convention symbolizes `self` in equivalent Python code. But it only holds that meaning for `PythonInstanceMethod` and not `PythonFunction`, which cannot bind to an object. Also, having to type `` `self` `` as the most ergonomic option possible more complex than typing `args`, due to backticks.

After this is decided, reverting the decision will be a **source-breaking change**.

@liuliu I would like your opinion, since you authored #40. The following data may help you decide, but does not influence my opinion. @pvieito please weigh in as well, if you have a preference. If the three of us do not all agree, we may need to seek other users' feedback on Swift Forums.

---

Swift-Colab 2.0 has the following distribution of calling conventions:
- single-argument: 6, including one that is not a `PythonInstanceMethod`
- multiple-argument: 4
- multiple-argument + keyword arguments: 1

Examining PythonFunctionTests.swift in PythonKit's tests, before #53:
- single-argument: 3
- multiple-argument: 7
- multiple-argument + keyword arguments: 0

Ergonomics data:
- Preferring one convention means the alternative must retain the old syntax. The phrase `(args: [PythonObject])` has the same number of non-alphanumeric symbols as ``(`self`: PythonObject)``. From my viewpoint, the `args` phrase seems more complex.
- Either convention will allow for more ergonomic ignoring of parameters, which means `{ (_: [PythonObject]) in ... }` becomes `{ _ in ... }`.
