### PR TITLE
Add a function to check if the PythonLibrary is valid to avoid Fatal Error during importing of "sys"

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -213,6 +213,12 @@ extension PythonLibrary {
         self.enforceNonLoadedPythonLibrary()
         PythonLibrary.Environment.library.set(path)
     }
+    
+    public static func checkLibrary() -> Bool {
+        let pythonLibraryHandleTest = Self.loadPythonLibrary()
+        return Self.isPythonLibraryLoaded(at: pythonLibraryHandleTest)
+    }
+    
 }
 
 // `PythonVersion` struct that defines a given Python version.

--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -214,7 +214,7 @@ extension PythonLibrary {
         PythonLibrary.Environment.library.set(path)
     }
     
-    public static func checkLibrary() -> Bool {
+    public static func libraryExists() -> Bool {
         let pythonLibraryHandleTest = Self.loadPythonLibrary()
         return Self.isPythonLibraryLoaded(at: pythonLibraryHandleTest)
     }


### PR DESCRIPTION
I added a new function to check if the PythonLibrary is valid or not, to avoid the fatal error during the importing of sys and to try a different path to import PythonLibrary.
I think it is a useful function because from MacOs 12.3 we can't assume that all users have Python 2 on their MacBook at the same path.