### PR TITLE
Add `with` statement feature

### DIFF
--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -722,6 +722,7 @@ public struct PythonInterface {
         return self.import("sys").version_info
     }
     
+    #if !os(Windows)
     /// Emulates a Python `with` statement.
     /// - Parameter object: A context manager object.
     /// - Parameter body: A closure to call on the result of `object.__enter__()`.
@@ -730,6 +731,7 @@ public struct PythonInterface {
         try body(yieldValue)
         yieldValue.__exit__()
     }
+    #endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -724,8 +724,7 @@ public struct PythonInterface {
     
     /// Emulates a Python `with` statement.
     /// - Parameter object: A context manager object.
-    /// - Parameter body: A closure to call over the result of `object.__enter__()`.
-    ///   Giving the input a name mirrors `with ... as` in Python.
+    /// - Parameter body: A closure to call on the result of `object.__enter__()`.
     public func with(_ object: PythonObject, _ body: (PythonObject) throws -> Void) rethrows {
         let yieldValue = object.__enter__()
         try body(yieldValue)

--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -721,6 +721,16 @@ public struct PythonInterface {
     public var versionInfo: PythonObject {
         return self.import("sys").version_info
     }
+    
+    /// Emulates a Python `with` statement.
+    /// - Parameter object: A context manager object.
+    /// - Parameter body: A closure to call over the result of `object.__enter__()`.
+    ///   Giving the input a name mirrors `with ... as` in Python.
+    public func with(_ object: PythonObject, _ body: (PythonObject) throws -> Void) rethrows {
+        let yieldValue = object.__enter__()
+        try body(yieldValue)
+        yieldValue.__exit__()
+    }
 }
 
 //===----------------------------------------------------------------------===//

--- a/PythonKit/Python.swift
+++ b/PythonKit/Python.swift
@@ -722,7 +722,6 @@ public struct PythonInterface {
         return self.import("sys").version_info
     }
     
-    #if !os(Windows)
     /// Emulates a Python `with` statement.
     /// - Parameter object: A context manager object.
     /// - Parameter body: A closure to call on the result of `object.__enter__()`.
@@ -731,7 +730,6 @@ public struct PythonInterface {
         try body(yieldValue)
         yieldValue.__exit__()
     }
-    #endif
 }
 
 //===----------------------------------------------------------------------===//

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -335,6 +335,7 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(bytes, otherBytes)
     }
     
+    #if !os(Windows)
     /// Tests an emulation of the Python `with` statement.
     ///
     /// Mirrors:
@@ -353,4 +354,5 @@ class PythonRuntimeTests: XCTestCase {
             XCTAssertEqual("Contents", String(contents)!)
         }
     }
+    #endif
 }

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -335,7 +335,6 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(bytes, otherBytes)
     }
     
-    #if !os(Windows)
     /// Tests an emulation of the Python `with` statement.
     ///
     /// Mirrors:
@@ -354,5 +353,4 @@ class PythonRuntimeTests: XCTestCase {
             XCTAssertEqual("Contents", String(contents)!)
         }
     }
-    #endif
 }

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -334,4 +334,23 @@ class PythonRuntimeTests: XCTestCase {
         }
         XCTAssertEqual(bytes, otherBytes)
     }
+    
+    /// Tests an emulation of the Python `with` statement.
+    ///
+    /// Mirrors:
+    /// ```python
+    /// with open('temp', 'w') as opened_file:
+    ///      opened_file.write('Contents')
+    /// with open('temp', 'r') as opened_file:
+    ///      contents = opened_file.read()
+    /// ```
+    func testWith() {
+        Python.with(Python.open("temp", "w")) { opened_file in
+            opened_file.write("Contents")
+        }
+        Python.with(Python.open("temp", "r")) { opened_file in
+            let contents = opened_file.read()
+            XCTAssertEqual("Contents", String(contents)!)
+        }
+    }
 }


### PR DESCRIPTION
Allow ergonomic usage of Python context managers by mirroring `with` statements. This deviates from the current API because it adds an instance method to `PythonInterface`. Most built-in Python functions are accessible through syntax like `Python.open` and `Python.classmethod`, which uses `@dynamicMemberLookup` . The most reasonable way to incorporate `with` is by treating it as a built-in function, `Python.with`. An alternative is `PythonWith`, which does not look very pleasant.

Before this pull request, using context managers was very cumbersome. You had to do the following just to disable gradients in PyTorch:

```swift
// some code
do { // encapsulate the temporary variable's scope
  let no_grad = torch.no_grad()
  no_grad.__enter__()
  defer { no_grad.__exit__() }
  
  // some code
}
// some code
```

This is possible to mess up (by forgetting to exit the context manager) and obfuscates the code's semantic meaning. I introduced a much more elegant solution:

```swift
// some code
Python.with(torch.no_grad()) { _ in
  // some code
}
// some code
```

This also emulates the `with expression() as result:` syntax. You can use the expression's return value as the input to the closure.

```swift
Python.with(Python.open("temp", "w")) { opened_file in
    opened_file.write("Contents")
}
```

## Potential Problems

If Python already had a built-in function called `with`, which was called using `with()`, this would create a source break. [No such function exists](https://docs.python.org/3/library/functions.html) at this moment, so there is no API break.