### PR TITLE
Silence Warning

### DIFF
--- a/PythonKit/NumpyConversion.swift
+++ b/PythonKit/NumpyConversion.swift
@@ -137,7 +137,7 @@ where Element : NumpyScalarCompatible {
         self.init(repeating: dummyPointer.move(), count: scalarCount)
         dummyPointer.deallocate()
         withUnsafeMutableBufferPointer { buffPtr in
-            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
+            buffPtr.baseAddress!.update(from: ptr, count: scalarCount)
         }
     }
 }


### PR DESCRIPTION
```
PythonKit/PythonKit/NumpyConversion.swift:140:34 'assign(from:count:)' is deprecated: renamed to 'update(from:count:)'