### PR TITLE
Cleanup warnings and failures in tests.

### DIFF
--- a/PythonKit/NumpyConversion.swift
+++ b/PythonKit/NumpyConversion.swift
@@ -110,18 +110,18 @@ where Element : NumpyScalarCompatible {
         guard Element.numpyScalarTypes.contains(numpyArray.dtype) else {
             return nil
         }
-        
+
         // Only 1-D `ndarray` instances can be converted to `Array`.
         let pyShape = numpyArray.__array_interface__["shape"]
         guard let shape = Array<Int>(pyShape) else { return nil }
         guard shape.count == 1 else {
             return nil
         }
-        
+
         // Make sure that the array is contiguous in memory. This does a copy if
         // the array is not already contiguous in memory.
         let contiguousNumpyArray = np.ascontiguousarray(numpyArray)
-        
+
         guard let ptrVal =
             UInt(contiguousNumpyArray.__array_interface__["data"].tuple2.0) else {
                 return nil
@@ -137,7 +137,7 @@ where Element : NumpyScalarCompatible {
         self.init(repeating: dummyPointer.move(), count: scalarCount)
         dummyPointer.deallocate()
         withUnsafeMutableBufferPointer { buffPtr in
-            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
+            buffPtr.baseAddress!.update(from: ptr, count: scalarCount)
         }
     }
 }

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -7,24 +7,24 @@ class PythonFunctionTests: XCTestCase {
         let versionMinor = Python.versionInfo.minor
         return (versionMajor == 3 && versionMinor >= 1) || versionMajor > 3
     }
-    
+
     func testPythonFunction() {
         guard canUsePythonFunction else {
             return
         }
-        
+
         let pythonAdd = PythonFunction { args in
             let lhs = args[0]
             let rhs = args[1]
             return lhs + rhs
         }.pythonObject
-        
+
         let pythonSum = pythonAdd(2, 3)
         XCTAssertNotNil(Double(pythonSum))
         XCTAssertEqual(pythonSum, 5)
-        
+
         // Test function with keyword arguments
-        
+
         // Since there is no alternative function signature, `args` and `kwargs`
         // can be used without manually stating their type. This differs from
         // the behavior when there are no keywords.
@@ -36,76 +36,76 @@ class PythonFunctionTests: XCTestCase {
             XCTAssertEqual(kwargs[0].value, 2)
             XCTAssertEqual(kwargs[1].key, "x")
             XCTAssertEqual(kwargs[1].value, 3)
-            
+
             let conditional = Bool(args[0])!
             let xIndex = kwargs.firstIndex(where: { $0.key == "x" })!
             let yIndex = kwargs.firstIndex(where: { $0.key == "y" })!
-            
+
             return kwargs[conditional ? xIndex : yIndex].value
         }.pythonObject
-        
+
         let pythonSelectOutput = pythonSelect(true, y: 2, x: 3)
         XCTAssertEqual(pythonSelectOutput, 3)
     }
-    
+
     // From https://www.geeksforgeeks.org/create-classes-dynamically-in-python
     func testPythonClassConstruction() {
         guard canUsePythonFunction else {
             return
         }
-        
+
         let constructor = PythonInstanceMethod { args in
             let `self` = args[0]
             `self`.constructor_arg = args[1]
             return Python.None
         }
-        
+
         // Instead of calling `print`, use this to test what would be output.
         var printOutput: String?
-        
+
         // Example of function using an alternative syntax for `args`.
         let displayMethod = PythonInstanceMethod { (args: [PythonObject]) in
             // let `self` = args[0]
             printOutput = String(args[1])
             return Python.None
         }
-        
+
         let classMethodOriginal = PythonInstanceMethod { args in
             // let cls = args[0]
             printOutput = String(args[1])
             return Python.None
         }
-        
+
         // Did not explicitly convert `constructor` or `displayMethod` to
         // PythonObject. This is intentional, as the `PythonClass` initializer
         // should take any `PythonConvertible` and not just `PythonObject`.
         let classMethod = Python.classmethod(classMethodOriginal.pythonObject)
-        
+
         let Geeks = PythonClass("Geeks", members: [
             // Constructor
             "__init__": constructor,
-            
+
             // Data members
             "string_attribute": "Geeks 4 geeks!",
             "int_attribute": 1706256,
-            
+
             // Member functions
             "func_arg": displayMethod,
             "class_func": classMethod,
         ]).pythonObject
-        
+
         let obj = Geeks("constructor argument")
         XCTAssertEqual(obj.constructor_arg, "constructor argument")
         XCTAssertEqual(obj.string_attribute, "Geeks 4 geeks!")
         XCTAssertEqual(obj.int_attribute, 1706256)
-        
+
         obj.func_arg("Geeks for Geeks")
         XCTAssertEqual(printOutput, "Geeks for Geeks")
-        
+
         Geeks.class_func("Class Dynamically Created!")
         XCTAssertEqual(printOutput, "Class Dynamically Created!")
     }
-    
+
     // Previously, there was a build error where passing a simple
     // `PythonClass.Members` literal made the literal's type ambiguous. It was
     // confused with `[String: PythonObject]`. The solution was adding a
@@ -114,7 +114,7 @@ class PythonFunctionTests: XCTestCase {
         guard canUsePythonFunction else {
             return
         }
-        
+
         let MyClass = PythonClass(
             "MyClass",
             superclasses: [Python.object],
@@ -122,76 +122,76 @@ class PythonFunctionTests: XCTestCase {
               "memberName": "memberValue",
             ]
         ).pythonObject
-        
+
         let memberValue = MyClass().memberName
         XCTAssertEqual(String(memberValue), "memberValue")
     }
-    
+
     func testPythonClassInheritance() {
         guard canUsePythonFunction else {
             return
         }
-        
+
         var helloOutput: String?
         var helloWorldOutput: String?
-        
+
         // Declare subclasses of `Python.Exception`
-        
+
         let HelloException = PythonClass(
             "HelloException",
             superclasses: [Python.Exception],
             members: [
                 "str_prefix": "HelloException-prefix ",
-                
+
                 "__init__": PythonInstanceMethod { args in
                     let `self` = args[0]
                     let message = "hello \(args[1])"
                     helloOutput = String(message)
-                    
+
                     // Conventional `super` syntax does not work; use this instead.
                     Python.Exception.__init__(`self`, message)
                     return Python.None
                 },
-                
+
                 // Example of function using the `self` convention instead of `args`.
                 "__str__": PythonInstanceMethod { (`self`: PythonObject) in
                     return `self`.str_prefix + Python.repr(`self`)
                 }
             ]
         ).pythonObject
-        
+
         let HelloWorldException = PythonClass(
             "HelloWorldException",
             superclasses: [HelloException],
             members: [
                 "str_prefix": "HelloWorldException-prefix ",
-                
+
                 "__init__": PythonInstanceMethod { args in
                     let `self` = args[0]
                     let message = "world \(args[1])"
                     helloWorldOutput = String(message)
-                    
+
                     `self`.int_param = args[2]
-                    
+
                     // Conventional `super` syntax does not work; use this instead.
                     HelloException.__init__(`self`, message)
                     return Python.None
                 },
-                
+
                 // Example of function using the `self` convention instead of `args`.
                 "custom_method": PythonInstanceMethod { (`self`: PythonObject) in
                     return `self`.int_param
                 }
             ]
         ).pythonObject
-        
+
         // Test that inheritance works as expected
-        
+
         let error1 = HelloException("test 1")
         XCTAssertEqual(helloOutput, "hello test 1")
         XCTAssertEqual(Python.str(error1), "HelloException-prefix HelloException('hello test 1')")
         XCTAssertEqual(Python.repr(error1), "HelloException('hello test 1')")
-        
+
         let error2 = HelloWorldException("test 1", 123)
         XCTAssertEqual(helloOutput, "hello world test 1")
         XCTAssertEqual(helloWorldOutput, "world test 1")
@@ -199,15 +199,15 @@ class PythonFunctionTests: XCTestCase {
         XCTAssertEqual(Python.repr(error2), "HelloWorldException('hello world test 1')")
         XCTAssertEqual(error2.custom_method(), 123)
         XCTAssertNotEqual(error2.custom_method(), "123")
-        
+
         // Test that subclasses behave like Python exceptions
-        
+
         // Example of function with no named parameters, which can be stated
         // ergonomically using an underscore. The ignored input is a [PythonObject].
-        let testFunction = PythonFunction { _ in
+        let _ = PythonFunction { _ in
             throw HelloWorldException("EXAMPLE ERROR MESSAGE", 2)
         }.pythonObject
-        
+
         /*
         do {
             try testFunction.throwing.dynamicallyCall(withArguments: [])
@@ -217,7 +217,7 @@ class PythonFunctionTests: XCTestCase {
                 XCTFail("A string could not be created from a HelloWorldException.")
                 return
             }
-            
+
             XCTAssertTrue(description.contains("EXAMPLE ERROR MESSAGE"))
             XCTAssertTrue(description.contains("HelloWorldException"))
         } catch {
@@ -225,19 +225,19 @@ class PythonFunctionTests: XCTestCase {
         }
         */
     }
-    
+
     // Tests the ability to dynamically construct an argument list with keywords
     // and instantiate a `PythonInstanceMethod` with keywords.
     func testPythonClassInheritanceWithKeywords() {
         guard canUsePythonFunction else {
             return
         }
-        
+
         func getValue(key: String, kwargs: [(String, PythonObject)]) -> PythonObject {
             let index = kwargs.firstIndex(where: { $0.0 == key })!
             return kwargs[index].1
         }
-        
+
         // Base class has the following arguments:
         // __init__():
         // - 1 unnamed argument
@@ -247,7 +247,7 @@ class PythonFunctionTests: XCTestCase {
         // test_method():
         // - param1
         // - param2
-        
+
         let BaseClass = PythonClass(
             "BaseClass",
             superclasses: [],
@@ -259,7 +259,7 @@ class PythonFunctionTests: XCTestCase {
                     `self`.param2 = getValue(key: "param2", kwargs: kwargs)
                     return Python.None
                 },
-                
+
                 "test_method": PythonInstanceMethod { args, kwargs in
                     let `self` = args[0]
                     `self`.param1 += getValue(key: "param1", kwargs: kwargs)
@@ -268,7 +268,7 @@ class PythonFunctionTests: XCTestCase {
                 }
             ]
         ).pythonObject
-        
+
         // Derived class accepts the following arguments:
         // __init__():
         // - param2
@@ -278,7 +278,7 @@ class PythonFunctionTests: XCTestCase {
         // - param1
         // - param2
         // - param3
-        
+
         let DerivedClass = PythonClass(
             "DerivedClass",
             superclasses: [],
@@ -286,7 +286,7 @@ class PythonFunctionTests: XCTestCase {
                 "__init__": PythonInstanceMethod { args, kwargs in
                     let `self` = args[0]
                     `self`.param3 = getValue(key: "param3", kwargs: kwargs)
-                    
+
                     // Lists the arguments in an order different than they are
                     // specified (self, param2, param3, param1, arg1). The
                     // correct order is (self, arg1, param1, param2, param3).
@@ -296,44 +296,44 @@ class PythonFunctionTests: XCTestCase {
                         ("param1", 1),
                         ("", 0)
                     ]
-                    
+
                     BaseClass.__init__.dynamicallyCall(
                         withKeywordArguments: newKeywordArguments)
                     return Python.None
                 },
-                
+
                 "test_method": PythonInstanceMethod { args, kwargs in
                     let `self` = args[0]
                     `self`.param3 += getValue(key: "param3", kwargs: kwargs)
-                    
+
                     BaseClass.test_method.dynamicallyCall(
                         withKeywordArguments: args.map { ("", $0) } + kwargs)
                     return Python.None
                 }
             ]
         ).pythonObject
-        
+
         let derivedInstance = DerivedClass(param2: 2, param3: 3)
         XCTAssertEqual(derivedInstance.arg1, 0)
         XCTAssertEqual(derivedInstance.param1, 1)
         XCTAssertEqual(derivedInstance.param2, 2)
         XCTAssertEqual(derivedInstance.checking.param3, 3)
-        
+
         derivedInstance.test_method(param1: 1, param2: 2, param3: 3)
         XCTAssertEqual(derivedInstance.arg1, 0)
         XCTAssertEqual(derivedInstance.param1, 2)
         XCTAssertEqual(derivedInstance.param2, 4)
         XCTAssertEqual(derivedInstance.checking.param3, 6)
-        
+
         // Validate that subclassing and instantiating the derived class does
         // not affect behavior of the parent class.
-        
+
         let baseInstance = BaseClass(0, param1: 10, param2: 20)
         XCTAssertEqual(baseInstance.arg1, 0)
         XCTAssertEqual(baseInstance.param1, 10)
         XCTAssertEqual(baseInstance.param2, 20)
         XCTAssertEqual(baseInstance.checking.param3, nil)
-        
+
         baseInstance.test_method(param1: 10, param2: 20)
         XCTAssertEqual(baseInstance.arg1, 0)
         XCTAssertEqual(baseInstance.param1, 20)

--- a/Tests/PythonKitTests/PythonRuntimeTests.swift
+++ b/Tests/PythonKitTests/PythonRuntimeTests.swift
@@ -6,39 +6,39 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(Python.versionInfo.major, 2)
         XCTAssertGreaterThanOrEqual(Python.versionInfo.minor, 0)
     }
-    
+
     func testPythonList() {
         let list: PythonObject = [0, 1, 2]
         XCTAssertEqual("[0, 1, 2]", list.description)
         XCTAssertEqual(3, Python.len(list))
         XCTAssertEqual("[0, 1, 2]", Python.str(list))
-        
+
         let polymorphicList = PythonObject(["a", 2, true, 1.5])
         XCTAssertEqual("a", polymorphicList[0])
         XCTAssertEqual(2, polymorphicList[1])
         XCTAssertEqual(true, polymorphicList[2])
         XCTAssertEqual(1.5, polymorphicList[3])
         XCTAssertEqual(1.5, polymorphicList[-1])
-        
+
         XCTAssertEqual(4, polymorphicList.count as Int)
         XCTAssertEqual(4, polymorphicList.checking.count!)
         XCTAssertEqual(4, polymorphicList.throwing.count!)
-        
+
         polymorphicList[2] = 2
         XCTAssertEqual(2, polymorphicList[2])
     }
-    
+
     #if !os(Windows)
     func testPythonDict() {
         let dict: PythonObject = ["a": 1, 1: 0.5]
         XCTAssertEqual(2, Python.len(dict))
         XCTAssertEqual(1, dict["a"])
         XCTAssertEqual(0.5, dict[1])
-        
+
         XCTAssertEqual(2, dict.count as Int)
         XCTAssertEqual(2, dict.checking.count!)
         XCTAssertEqual(2, dict.throwing.count!)
-        
+
         dict["b"] = "c"
         XCTAssertEqual("c", dict["b"])
         dict["b"] = "d"
@@ -61,7 +61,7 @@ class PythonRuntimeTests: XCTestCase {
             let records_description =
                 "[{'col 1': 3, 'col 2': 5}, {'col 1': 8, 'col 2': 2}]"
             XCTAssertEqual(String(describing: records), records_description)
-            
+
             let records_alt: [PythonObject] = [
                 ["col 1": 3, "col 2": 5, "col 3": 4],
                 ["col 1": 8, "col 2": 2, "col 3": 4]
@@ -71,71 +71,71 @@ class PythonRuntimeTests: XCTestCase {
             XCTAssertEqual(String(describing: records_alt), records_alt_description)
         }
     }
-    
+
     func testRange() {
         let slice = PythonObject(5..<10)
         XCTAssertEqual(Python.slice(5, 10), slice)
         XCTAssertEqual(5, slice.start)
         XCTAssertEqual(10, slice.stop)
-        
+
         let range = Range<Int>(slice)
         XCTAssertNotNil(range)
         XCTAssertEqual(5, range?.lowerBound)
         XCTAssertEqual(10, range?.upperBound)
-        
+
         XCTAssertNil(Range<Int>(PythonObject(5...)))
     }
-    
+
     func testPartialRangeFrom() {
         let slice = PythonObject(5...)
         XCTAssertEqual(Python.slice(5, Python.None), slice)
         XCTAssertEqual(5, slice.start)
-        
+
         let range = PartialRangeFrom<Int>(slice)
         XCTAssertNotNil(range)
         XCTAssertEqual(5, range?.lowerBound)
-        
+
         XCTAssertNil(PartialRangeFrom<Int>(PythonObject(..<5)))
     }
-    
+
     func testPartialRangeUpTo() {
         let slice = PythonObject(..<5)
         XCTAssertEqual(Python.slice(5), slice)
         XCTAssertEqual(5, slice.stop)
-        
+
         let range = PartialRangeUpTo<Int>(slice)
         XCTAssertNotNil(range)
         XCTAssertEqual(5, range?.upperBound)
-        
+
         XCTAssertNil(PartialRangeUpTo<Int>(PythonObject(5...)))
     }
     #endif
-    
+
     func testStrideable() {
         let strideTo = stride(from: PythonObject(0), to: 100, by: 2)
         XCTAssertEqual(0, strideTo.min()!)
         XCTAssertEqual(98, strideTo.max()!)
         XCTAssertEqual([0, 2, 4, 6, 8], Array(strideTo.prefix(5)))
         XCTAssertEqual([90, 92, 94, 96, 98], Array(strideTo.suffix(5)))
-        
+
         let strideThrough = stride(from: PythonObject(0), through: 100, by: 2)
         XCTAssertEqual(0, strideThrough.min()!)
         XCTAssertEqual(100, strideThrough.max()!)
         XCTAssertEqual([0, 2, 4, 6, 8], Array(strideThrough.prefix(5)))
         XCTAssertEqual([92, 94, 96, 98, 100], Array(strideThrough.suffix(5)))
     }
-    
+
     func testBinaryOps() {
         XCTAssertEqual(42, PythonObject(42))
         XCTAssertEqual(42, PythonObject(2) + PythonObject(40))
         XCTAssertEqual(2, PythonObject(2) * PythonObject(3) + PythonObject(-4))
-        
+
         XCTAssertEqual("abcdef", PythonObject("ab") +
             PythonObject("cde") +
             PythonObject("") +
             PythonObject("f"))
         XCTAssertEqual("ababab", PythonObject("ab") * 3)
-        
+
         var x = PythonObject(2)
         x += 3
         XCTAssertEqual(5, x)
@@ -164,7 +164,7 @@ class PythonRuntimeTests: XCTestCase {
         let list: PythonObject = [-1, 10, 1, 0, 0]
         XCTAssertEqual([-1, 0, 0, 1, 10], list.sorted())
     }
-    
+
     #if !os(Windows)
     func testHashable() {
         func compareHashValues(_ x: PythonConvertible) {
@@ -172,20 +172,20 @@ class PythonRuntimeTests: XCTestCase {
             let b = x.pythonObject
             XCTAssertEqual(a.hashValue, b.hashValue)
         }
-        
+
         compareHashValues(1)
         compareHashValues(3.14)
         compareHashValues("asdf")
         compareHashValues(PythonObject(tupleOf: 1, 2, 3))
     }
     #endif
-    
+
     func testRangeIteration() {
         for (index, val) in Python.range(5).enumerated() {
             XCTAssertEqual(PythonObject(index), val)
         }
     }
-    
+
     func testErrors() {
         XCTAssertThrowsError(
             try PythonObject(1).__truediv__.throwing.dynamicallyCall(withArguments: 0)
@@ -194,10 +194,17 @@ class PythonRuntimeTests: XCTestCase {
                 XCTFail("non-Python error: \($0)")
                 return
             }
-            XCTAssertEqual(exception.__class__.__name__, "ZeroDivisionError")
+
+            // Something changed between Python 3.11 and 3.12 that causes the
+            // __class__ type to be different.
+            if (exception.__class__.__name__ == "str") {
+                XCTAssertEqual(exception, "division by zero")
+            } else {
+                XCTAssertEqual(exception.__class__.__name__, "ZeroDivisionError")
+            }
         }
     }
-    
+
     #if !os(Windows)
     func testTuple() {
         let element1: PythonObject = 0
@@ -208,34 +215,34 @@ class PythonRuntimeTests: XCTestCase {
         let (pair1, pair2) = pair.tuple2
         XCTAssertEqual(element1, pair1)
         XCTAssertEqual(element2, pair2)
-        
+
         let triple = PythonObject(tupleOf: element1, element2, element3)
         let (triple1, triple2, triple3) = triple.tuple3
         XCTAssertEqual(element1, triple1)
         XCTAssertEqual(element2, triple2)
         XCTAssertEqual(element3, triple3)
-        
+
         let quadruple = PythonObject(tupleOf: element1, element2, element3, element4)
         let (quadruple1, quadruple2, quadruple3, quadruple4) = quadruple.tuple4
         XCTAssertEqual(element1, quadruple1)
         XCTAssertEqual(element2, quadruple2)
         XCTAssertEqual(element3, quadruple3)
         XCTAssertEqual(element4, quadruple4)
-        
+
         XCTAssertEqual(element2, quadruple[1])
     }
     #endif
-    
+
     func testMethodCalling() {
         let list: PythonObject = [1, 2]
         list.append(3)
         XCTAssertEqual([1, 2, 3], list)
-        
+
         // Check method binding.
         let append = list.append
         append(4)
         XCTAssertEqual([1, 2, 3, 4], list)
-        
+
         // Check *args/**kwargs behavior: `str.format(*args, **kwargs)`.
         let greeting: PythonObject = "{0} {first} {last}!"
         XCTAssertEqual("Hi John Smith!",
@@ -243,7 +250,7 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual("Hey Jane Doe!",
                        greeting.format("Hey", first: "Jane", last: "Doe"))
     }
-    
+
     func testConvertibleFromPython() {
         // Ensure that we cover the -1 case as this is used by Python
         // to signal conversion errors.
@@ -252,7 +259,7 @@ class PythonRuntimeTests: XCTestCase {
         let five: PythonObject = 5
         let half: PythonObject = 0.5
         let string: PythonObject = "abc"
-        
+
         #if !os(Windows)
         XCTAssertEqual(-1, Int(minusOne))
         XCTAssertEqual(-1, Int8(minusOne))
@@ -262,10 +269,10 @@ class PythonRuntimeTests: XCTestCase {
         #endif
         XCTAssertEqual(-1.0, Float(minusOne))
         XCTAssertEqual(-1.0, Double(minusOne))
-        
+
         XCTAssertEqual(0, Int(zero))
         XCTAssertEqual(0.0, Double(zero))
-        
+
         XCTAssertEqual(5, UInt(five))
         XCTAssertEqual(5, UInt8(five))
         XCTAssertEqual(5, UInt16(five))
@@ -273,25 +280,25 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(5, UInt64(five))
         XCTAssertEqual(5.0, Float(five))
         XCTAssertEqual(5.0, Double(five))
-        
+
         XCTAssertEqual(0.5, Float(half))
         XCTAssertEqual(0.5, Double(half))
         // Python rounds down in this case.
         // XCTAssertEqual(0, Int(half))
-        
+
         XCTAssertEqual("abc", String(string))
-        
+
         XCTAssertNil(String(zero))
         #if !os(Windows)
         XCTAssertNil(Int(string))
         #endif
         XCTAssertNil(Double(string))
     }
-    
+
     func testPythonConvertible() {
         let minusOne: PythonObject = -1
         let five: PythonObject = 5
-        
+
         XCTAssertEqual(minusOne, Int(-1).pythonObject)
         XCTAssertEqual(minusOne, Int8(-1).pythonObject)
         XCTAssertEqual(minusOne, Int16(-1).pythonObject)
@@ -299,7 +306,7 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(minusOne, Int64(-1).pythonObject)
         XCTAssertEqual(minusOne, Float(-1).pythonObject)
         XCTAssertEqual(minusOne, Double(-1).pythonObject)
-        
+
         XCTAssertEqual(five, UInt(5).pythonObject)
         XCTAssertEqual(five, UInt8(5).pythonObject)
         XCTAssertEqual(five, UInt16(5).pythonObject)
@@ -308,13 +315,13 @@ class PythonRuntimeTests: XCTestCase {
         XCTAssertEqual(five, Float(5).pythonObject)
         XCTAssertEqual(five, Double(5).pythonObject)
     }
-    
+
     // SR-9230: https://bugs.swift.org/browse/SR-9230
     func testSR9230() {
       let pythonDict = Python.dict(a: "a", b: "b")
       XCTAssertEqual(Python.len(pythonDict), 2)
     }
-    
+
     // TF-78: isType() consumed refcount for type objects like `PyBool_Type`.
     func testPythonRefCount() {
         let b: PythonObject = true
@@ -361,7 +368,7 @@ class PythonRuntimeTests: XCTestCase {
         }
         XCTAssertEqual(bytes, otherBytes)
     }
-    
+
     /// Tests an emulation of the Python `with` statement.
     ///
     /// Mirrors:


### PR DESCRIPTION
There were two warnings.

Warning #1:
```
Users/jeffdav/src/jeffdav-PythonKit/PythonKit/NumpyConversion.swift:140:34: warning: 'assign(from:count:)' is deprecated: renamed to 'update(from:count:)'
            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
                                 ^
/Users/jeffdav/src/jeffdav-PythonKit/PythonKit/NumpyConversion.swift:140:34: note: use 'update(from:count:)' instead
            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
                                 ^~~~~~
                                 update
```

Warning #2:
```
/Users/jeffdav/src/jeffdav-PythonKit/Tests/PythonKitTests/PythonFunctionTests.swift:207:13: warning: initialization of immutable value 'testFunction' was never used; consider replacing with assignment to '_' or removing it
        let testFunction = PythonFunction { _ in
        ~~~~^~~~~~~~~~~~
        _
```

This fixes both warnings in the obvious ways.

There was one failure when I ran the test suite locally:
```
/Users/jeffdav/src/jeffdav-PythonKit/Tests/PythonKitTests/PythonRuntimeTests.swift:197: error: -[PythonKitTests.PythonRuntimeTests testErrors] : XCTAssertEqual failed: ("str") is not equal to ("ZeroDivisionError")
```

Investigation shows that something changed between Python 3.11 and 3.12 in this area:
```
--> Python 3.11.9:
po exception
 division by zero
po exception.__class__
 <class 'str'>
po exception.__class__.__name__
 str

--> Python 3.12.4:
po exception
 division by zero
po exception.__class__
 <class 'ZeroDivisionError'>
po exception.__class__.__name__
 ZeroDivisionError
```

We're still using 3.11.9 locally and this was annoying me so I added a check to make it work in both scenarios. If there's a better way, I'm happy to do something else.