### PR TITLE
Fix warnings.

### DIFF
--- a/PythonKit/NumpyConversion.swift
+++ b/PythonKit/NumpyConversion.swift
@@ -137,7 +137,7 @@ where Element : NumpyScalarCompatible {
         self.init(repeating: dummyPointer.move(), count: scalarCount)
         dummyPointer.deallocate()
         withUnsafeMutableBufferPointer { buffPtr in
-            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
+            buffPtr.baseAddress!.update(from: ptr, count: scalarCount)
         }
     }
 }

--- a/Tests/PythonKitTests/PythonFunctionTests.swift
+++ b/Tests/PythonKitTests/PythonFunctionTests.swift
@@ -204,7 +204,7 @@ class PythonFunctionTests: XCTestCase {
 
         // Example of function with no named parameters, which can be stated
         // ergonomically using an underscore. The ignored input is a [PythonObject].
-        let testFunction = PythonFunction { _ in
+        let _ = PythonFunction { _ in
             throw HelloWorldException("EXAMPLE ERROR MESSAGE", 2)
         }.pythonObject
 


### PR DESCRIPTION
This fixes the following two warnings:

```swift
/Users/jeffdav/src/jeffdav-PythonKit/PythonKit/NumpyConversion.swift:140:34: warning: 'assign(from:count:)' is deprecated: renamed to 'update(from:count:)'
            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
                                 ^
/Users/jeffdav/src/jeffdav-PythonKit/PythonKit/NumpyConversion.swift:140:34: note: use 'update(from:count:)' instead
            buffPtr.baseAddress!.assign(from: ptr, count: scalarCount)
                                 ^~~~~~
                                 update
/Users/jeffdav/src/jeffdav-PythonKit/Tests/PythonKitTests/PythonFunctionTests.swift:207:13: warning: initialization of immutable value 'testFunction' was never used; consider replacing with assignment to '_' or removing it
        let testFunction = PythonFunction { _ in
        ~~~~^~~~~~~~~~~~
        _
```