### PR TITLE
windows: Fix insecure CRT warning about getenv.

### DIFF
--- a/PythonKit/PythonLibrary.swift
+++ b/PythonKit/PythonLibrary.swift
@@ -284,7 +284,17 @@ extension PythonLibrary {
         }
 
         var value: String? {
+#if os(Windows)
+            var cString: UnsafeMutablePointer<CChar>? = nil
+            var size: size_t = 0
+            let result = _dupenv_s(&cString, &size, key)
+            defer {
+                if let cString { free(cString) }
+            }
+            guard result == 0, let cString else { return nil }
+#else
             guard let cString = getenv(key) else { return nil }
+#endif
             let value = String(cString: cString)
             guard !value.isEmpty else { return nil }
             return value


### PR DESCRIPTION
Building on Windows, I saw:
```pwsh
PS jeffdav\PythonKit> swift build
Building for debugging...
C:\Users\jeffdav\PythonKit\PythonKit\PythonLibrary.swift:287:33: warning: 'getenv' is deprecated: This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [#DeprecatedDeclaration]
285 |
286 |         var value: String? {
287 |             guard let cString = getenv(key) else { return nil }
    |                                 `- warning: 'getenv' is deprecated: This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. [#DeprecatedDeclaration]
```

This switches the code to use `_dupenv_s()` instead, which is pretty straightforward.